### PR TITLE
Update maxBufferElements to return coords for all arrays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.tiledb'
-version '0.1.0'
+version '0.1.1'
 
 apply plugin: 'java'
 apply plugin: 'idea'

--- a/src/main/java/io/tiledb/java/api/Array.java
+++ b/src/main/java/io/tiledb/java/api/Array.java
@@ -278,22 +278,21 @@ public class Array implements AutoCloseable {
                      tiledb.tiledb_datatype_size(a.getValue().getType().toSwigEnum()).longValue()));
       }
     }
-    if (schema.isSparse()) {
-      try {
-        ctx.handleError(tiledb.tiledb_array_max_buffer_size(
-                ctx.getCtxp(),
-                arrayp,
-                tiledb.tiledb_coords(),
-                subarray.toVoidPointer(),
-                val_nbytes.cast()));
-      } catch (TileDBError err) {
-        val_nbytes.delete();
-      }
-      ret.put(tiledb.tiledb_coords(),
-            new Pair(0l, val_nbytes.getitem(0).longValue() /
-                 tiledb.tiledb_datatype_size(schema.getDomain().getType().toSwigEnum()).longValue()));
+    // Add coordinates
+    try {
+      ctx.handleError(tiledb.tiledb_array_max_buffer_size(
+              ctx.getCtxp(),
+              arrayp,
+              tiledb.tiledb_coords(),
+              subarray.toVoidPointer(),
+              val_nbytes.cast()));
+    } catch (TileDBError err) {
+      val_nbytes.delete();
+    }
+    ret.put(tiledb.tiledb_coords(),
+          new Pair(0l, val_nbytes.getitem(0).longValue() /
+               tiledb.tiledb_datatype_size(schema.getDomain().getType().toSwigEnum()).longValue()));
 
-    } 
     off_nbytes.delete();
     val_nbytes.delete();
     return ret;


### PR DESCRIPTION
Update maxBufferElements to return coords for all arrays not just sparse arrays.

This also bumps the patch version number.