### PR TITLE
Bump snapshot version to 0.1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.1.6-SNAPSHOT'
+version '0.1.7-SNAPSHOT'
 
 repositories {
     jcenter()


### PR DESCRIPTION
Bumping the master branch version number to 0.1.7-SNAPSHOT since 0.1.6 has been released.