### PR TITLE
Don't sign for task publishToMavenLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,8 +147,8 @@ gradle.taskGraph.whenReady { taskGraph ->
         allprojects { ext."signing.password" = System.getenv('GPG_PASSPHRASE') }
     }
     // Do not sign archives by default (a local build without gpg keyring should succeed)
-    if (taskGraph.allTasks.any { it.name == 'build' || it.name == 'assemble' }) {
-        tasks.findAll { it.name == 'signArchives' || it.name == 'signDocsJar' || it.name == 'signTestJar' }.each { task ->
+    if (taskGraph.allTasks.any { it.name == 'build' || it.name == 'assemble'  || it.name == 'publishToMavenLocal'}) {
+        tasks.findAll { it.name == 'signArchives' || it.name == 'signDocsJar' || it.name == 'signTestJar' || it.name == 'signMavenJavaPublication'}.each { task ->
             task.enabled = false
         }
     }


### PR DESCRIPTION
One day we should switch back to automatic handling of signing. This PR fixes the issue that exist with attempting to sign the jars when pushing to local maven.