### PR TITLE
Add support for type checking java classes.

### DIFF
--- a/src/main/java/io/tiledb/java/api/Datatype.java
+++ b/src/main/java/io/tiledb/java/api/Datatype.java
@@ -72,6 +72,52 @@ public enum Datatype {
     }
   }
 
+  /**
+   * Returns the equivalent java class for a given TileDB Type
+   *
+   * @return class
+   * @throws TileDBError
+   */
+  public Class javaClass() throws TileDBError {
+    switch (this) {
+      case TILEDB_INT32:
+        return Integer.class;
+      case TILEDB_INT64:
+        return Long.class;
+      case TILEDB_FLOAT32:
+        return Float.class;
+      case TILEDB_FLOAT64:
+        return Double.class;
+      case TILEDB_CHAR:
+        return Short.class;
+      case TILEDB_INT8:
+        return Byte.class;
+      case TILEDB_UINT8:
+        return Short.class;
+      case TILEDB_INT16:
+        return Short.class;
+      case TILEDB_UINT16:
+        return Integer.class;
+      case TILEDB_UINT32:
+        return Long.class;
+      case TILEDB_UINT64:
+        return Long.class;
+      case TILEDB_STRING_UTF8:
+        return String.class;
+      case TILEDB_STRING_UTF16:
+        return String.class;
+      case TILEDB_STRING_UTF32:
+        return String.class;
+      case TILEDB_STRING_UCS2:
+        return String.class;
+      case TILEDB_STRING_UCS4:
+        return String.class;
+      case TILEDB_ANY:
+      default:
+        throw new TileDBError("No such enum value" + this.name());
+    }
+  }
+
   protected tiledb_datatype_t toSwigEnum() throws TileDBError {
     switch (this) {
       case TILEDB_INT32:

--- a/src/main/java/io/tiledb/java/api/Query.java
+++ b/src/main/java/io/tiledb/java/api/Query.java
@@ -179,8 +179,11 @@ public class Query implements AutoCloseable {
       dimType = domain.getType();
     }
 
-    Types.typeCheck(Types.getNativeType(start.getClass()), dimType);
-    Types.typeCheck(Types.getNativeType(end.getClass()), dimType);
+    // We use java type check here because we can not tell the difference between unsigned and
+    // signed
+    // values coming from java, i.e. A UINT16 and INT32 are both Integer classes in java.
+    Types.javaTypeCheck(start.getClass(), dimType.javaClass());
+    Types.javaTypeCheck(end.getClass(), dimType.javaClass());
 
     try (NativeArray startArr = new NativeArray(ctx, 1, dimType);
         NativeArray endArr = new NativeArray(ctx, 1, dimType)) {

--- a/src/main/java/io/tiledb/java/api/Types.java
+++ b/src/main/java/io/tiledb/java/api/Types.java
@@ -128,4 +128,20 @@ public class Types {
     }
     return true;
   }
+
+  /**
+   * Checks two class types are equal
+   *
+   * @param first class to compare
+   * @param second class to compare
+   * @return true if classes are equal else false
+   * @throws TileDBError
+   */
+  public static boolean javaTypeCheck(Class first, Class second) throws TileDBError {
+    if (!first.equals(second)) {
+      throw new TileDBError(
+          "Type " + first.getName() + " is not equal to the default getType: " + second.getName());
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
This is needed because we can't type check against UINT32 vs INT64, or any other unsigned vs signed since java has no unsigned integers