### PR TITLE
Expose Array Metadata functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build/*
 */.gradle/*
 */build/*
 */performance_test/*
+.classpath
+.project
+.settings
+bin/

--- a/src/main/java/io/tiledb/java/api/Array.java
+++ b/src/main/java/io/tiledb/java/api/Array.java
@@ -615,6 +615,122 @@ public class Array implements AutoCloseable {
     return ret;
   }
 
+  /**
+   * Get a metadata key-value item from an open array. The array must be opened in READ mode,
+   * otherwise the function will error out.
+   *
+   * @param key a key to retrieve from the metadata key-value
+   * @param nativeType The Datatype
+   * @return NativeArray which contains the metadata
+   * @throws TileDBError A TileDB exception
+   */
+  public NativeArray getMetadata(String key, Datatype nativeType) throws TileDBError {
+    checkIsOpen();
+
+    SWIGTYPE_p_p_void resultArrpp = tiledb.new_voidpArray(0);
+    SWIGTYPE_p_unsigned_int value_num = tiledb.new_uintp();
+    SWIGTYPE_p_tiledb_datatype_t value_type =
+        tiledb.copy_tiledb_datatype_tp(nativeType.toSwigEnum());
+
+    ctx.handleError(
+        tiledb.tiledb_array_get_metadata(
+            ctx.getCtxp(), arrayp, key, value_type, value_num, resultArrpp));
+
+    long value = tiledb.uintp_value(value_num);
+    NativeArray result = new NativeArray(ctx, nativeType, resultArrpp, (int) value);
+
+    tiledb.delete_uintp(value_num);
+    tiledb.delete_tiledb_datatype_tp(value_type);
+
+    return result;
+  }
+
+  /**
+   * Deletes a metadata key-value item from an open array. The array must be opened in WRITE mode,
+   * otherwise the function will error out.
+   *
+   * @param key a key to delete from the metadata key-value
+   * @throws TileDBError A TileDB exception
+   */
+  public void deleteMetadata(String key) throws TileDBError {
+    checkIsOpen();
+
+    ctx.handleError(tiledb.tiledb_array_delete_metadata(ctx.getCtxp(), arrayp, key));
+  }
+
+  /**
+   * Gets the number of metadata items in an open array. The array must be opened in READ mode,
+   * otherwise the function will error out.
+   *
+   * @return the number of metadata items
+   * @throws TileDBError A TileDB exception
+   */
+  public BigInteger getMetadataNum() throws TileDBError {
+    checkIsOpen();
+
+    SWIGTYPE_p_unsigned_long_long value_num = tiledb.new_ullp();
+
+    ctx.handleError(tiledb.tiledb_array_get_metadata_num(ctx.getCtxp(), arrayp, value_num));
+
+    BigInteger value = tiledb.ullp_value(value_num);
+
+    tiledb.delete_ullp(value_num);
+
+    return value;
+  }
+
+  /**
+   * Gets a metadata item from an open array using an index. The array must be opened in READ mode,
+   * otherwise the function will error out.
+   *
+   * @param index index to retrieve metadata from
+   * @return a pair, key and the metadata NativeArray
+   * @throws TileDBError A TileDB exception
+   */
+  public Pair getMetadataFromIndex(BigInteger index) throws TileDBError {
+    checkIsOpen();
+
+    SWIGTYPE_p_p_char key = tiledb.new_charpp();
+    SWIGTYPE_p_unsigned_int key_len = tiledb.new_uintp();
+    SWIGTYPE_p_tiledb_datatype_t value_type = tiledb.new_tiledb_datatype_tp();
+    SWIGTYPE_p_unsigned_int value_num = tiledb.new_uintp();
+    SWIGTYPE_p_p_void value = tiledb.new_voidpArray(0);
+
+    ctx.handleError(
+        tiledb.tiledb_array_get_metadata_from_index(
+            ctx.getCtxp(), arrayp, index, key, key_len, value_type, value_num, value));
+
+    String keyString = tiledb.charpp_value(key);
+    long valueLength = tiledb.uintp_value(value_num);
+    Datatype nativeType = Datatype.fromSwigEnum(tiledb.tiledb_datatype_tp_value(value_type));
+
+    NativeArray result = new NativeArray(ctx, nativeType, value, (int) valueLength);
+
+    tiledb.delete_uintp(value_num);
+    tiledb.delete_uintp(key_len);
+    tiledb.delete_charpp(key);
+    tiledb.delete_tiledb_datatype_tp(value_type);
+
+    return new Pair(keyString, result);
+  }
+
+  public Boolean hasMetadataKey(String key) throws TileDBError {
+    checkIsOpen();
+
+    SWIGTYPE_p_tiledb_datatype_t value_type = tiledb.new_tiledb_datatype_tp();
+    SWIGTYPE_p_int has_key = tiledb.new_intp();
+
+    ctx.handleError(
+        tiledb.tiledb_array_has_metadata_key(ctx.getCtxp(), arrayp, key, value_type, has_key));
+
+    Boolean result = tiledb.intp_value(has_key) > 0;
+
+    tiledb.delete_intp(has_key);
+    tiledb.delete_tiledb_datatype_tp(value_type);
+
+    return result;
+  }
+
   /** @return The TileDB Context object associated with the Array instance. */
   public Context getCtx() {
     return ctx;

--- a/src/main/java/io/tiledb/java/api/Array.java
+++ b/src/main/java/io/tiledb/java/api/Array.java
@@ -684,10 +684,10 @@ public class Array implements AutoCloseable {
    * otherwise the function will error out.
    *
    * @param index index to retrieve metadata from
-   * @return a pair, key and the metadata NativeArray
+   * @return a pair, key and the metadata
    * @throws TileDBError A TileDB exception
    */
-  public Pair getMetadataFromIndex(BigInteger index) throws TileDBError {
+  public Pair<String, NativeArray> getMetadataFromIndex(BigInteger index) throws TileDBError {
     checkIsOpen();
 
     SWIGTYPE_p_p_char key = tiledb.new_charpp();
@@ -711,7 +711,7 @@ public class Array implements AutoCloseable {
     tiledb.delete_charpp(key);
     tiledb.delete_tiledb_datatype_tp(value_type);
 
-    return new Pair(keyString, result);
+    return new Pair<String, NativeArray>(keyString, result);
   }
 
   /**

--- a/src/main/java/io/tiledb/java/api/Array.java
+++ b/src/main/java/io/tiledb/java/api/Array.java
@@ -714,6 +714,13 @@ public class Array implements AutoCloseable {
     return new Pair(keyString, result);
   }
 
+  /**
+   * Checks if the key is present in the Array metadata
+   *
+   * @param key a key to retrieve from the metadata key-value
+   * @return true if the key is present in the metadata, false if it is not
+   * @throws TileDBError A TileDB exception
+   */
   public Boolean hasMetadataKey(String key) throws TileDBError {
     checkIsOpen();
 
@@ -729,6 +736,27 @@ public class Array implements AutoCloseable {
     tiledb.delete_tiledb_datatype_tp(value_type);
 
     return result;
+  }
+
+  /**
+   * Puts a metadata key-value item to an open array. The array must be opened in WRITE mode,
+   * otherwise the function will error out.
+   *
+   * @param key a key to assign to the input value
+   * @param value the metadata to put into the Array metadata
+   * @throws TileDBError A TileDB exception
+   */
+  public void putMetadata(String key, NativeArray value) throws TileDBError {
+    checkIsOpen();
+
+    ctx.handleError(
+        tiledb.tiledb_array_put_metadata(
+            ctx.getCtxp(),
+            arrayp,
+            key,
+            value.getNativeType().toSwigEnum(),
+            value.getSize(),
+            value.toVoidPointer()));
   }
 
   /** @return The TileDB Context object associated with the Array instance. */

--- a/src/main/java/io/tiledb/java/api/Array.java
+++ b/src/main/java/io/tiledb/java/api/Array.java
@@ -715,7 +715,8 @@ public class Array implements AutoCloseable {
   }
 
   /**
-   * Checks if the key is present in the Array metadata
+   * Checks if the key is present in the Array metadata. The array must be opened in READ mode,
+   * otherwise the function will error out.
    *
    * @param key a key to retrieve from the metadata key-value
    * @return true if the key is present in the metadata, false if it is not

--- a/src/test/java/io/tiledb/java/api/ArrayTest.java
+++ b/src/test/java/io/tiledb/java/api/ArrayTest.java
@@ -34,6 +34,16 @@ public class ArrayTest {
     ctx.close();
   }
 
+  private Object[] getArray(Object val) {
+    if (val instanceof Object[]) return (Object[]) val;
+    int arrlength = java.lang.reflect.Array.getLength(val);
+    Object[] outputArray = new Object[arrlength];
+    for (int i = 0; i < arrlength; i++) {
+      outputArray[i] = java.lang.reflect.Array.get(val, i);
+    }
+    return outputArray;
+  }
+
   public ArraySchema schemaCreate() throws Exception {
     Dimension<Long> d1 =
         new Dimension<Long>(ctx, "d1", Long.class, new Pair<Long, Long>(1l, 4l), 2l);
@@ -287,7 +297,7 @@ public class ArrayTest {
 
     arrayw.putMetadata(intKey, metadataInt);
     arrayw.putMetadata(floatKey, metadataFloat);
-    // commit changes
+    // submit changes
     arrayw.close();
 
     // open a new session
@@ -309,17 +319,13 @@ public class ArrayTest {
         (float[]) metadataFloat.toJavaArray(), (float[]) metadataFloatActual.toJavaArray(), 1e-10f);
 
     // fromIndex tests
-    String[] keys = new String[] {floatKey, intKey};
+    String[] expectedKeys = new String[] {floatKey, intKey};
+    Object[] expectedArrays = new Object[] {metadataFloat.toJavaArray(), metadataInt.toJavaArray()};
+
     for (int i = 0; i < arrayn.getMetadataNum().intValue(); i++) {
       Pair<String, NativeArray> p = arrayn.getMetadataFromIndex(BigInteger.valueOf(i));
-      Assert.assertEquals(p.getFirst(), keys[i]);
-      if (i == 0) {
-        Assert.assertArrayEquals(
-            (float[]) metadataFloat.toJavaArray(), (float[]) p.getSecond().toJavaArray(), 1e-10f);
-      } else {
-        Assert.assertArrayEquals(
-            (int[]) metadataInt.toJavaArray(), (int[]) p.getSecond().toJavaArray());
-      }
+      Assert.assertEquals(expectedKeys[i], p.getFirst());
+      Assert.assertArrayEquals(getArray(expectedArrays[i]), getArray(p.getSecond().toJavaArray()));
     }
 
     arrayn.close();


### PR DESCRIPTION
This PR is the first attempt to expose missing Array metadata functions. This piece of functionality is neccesary to allow proper reads of tiledb files [written via GDAL](https://github.com/OSGeo/gdal/blob/v3.1.0RC2/gdal/frmts/tiledb/tiledbdataset.cpp).

I hope it aligns with your development plans, and finally [this Java bindings docs page](https://docs.tiledb.com/developer/api-usage/array-metadata) would not be empty anymore.  