### PR TITLE
Azure Pipelines - Added build and release stages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,33 +12,73 @@ trigger:
     include:
       - "*"
 
-jobs:
-    - job: Windows
-      strategy:
-        matrix:
-          VS2019:
-            imageName: 'windows-2019'
-            TILEDB_S3: ON
-      pool:
-        vmImage: $(imageName)
-      steps:
-        - task: Gradle@2
-          inputs:
-            workingDirectory: ''
-            gradleWrapperFile: 'gradlew.bat'
-            gradleOptions: '-Xmx3072m'
-            javaHomeOption: 'JDKVersion'
-            jdkVersionOption: 'default'
-            tasks: 'assemble test'
+stages:
+  - stage: CI
+    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+    jobs:
+      - job: Windows
+        strategy:
+          matrix:
+            VS2019:
+              imageName: 'windows-2019'
+              TILEDB_S3: ON
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - task: Gradle@2
+            inputs:
+              workingDirectory: ''
+              gradleWrapperFile: 'gradlew.bat'
+              gradleOptions: '-Xmx3072m'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: 'default'
+              tasks: 'checkFormat assemble test'
 
-    - job: Linux_OSX
-      strategy:
-        matrix:
-          ubuntu_18:
-            imageName: 'ubuntu-18.04'
-          macOS:
-            imageName: 'macOS-10.14'
-      pool:
-        vmImage: $(imageName)
-      steps:
-        - template: ci/tiledb-java-azure.yml
+      - job: Linux_OSX
+        strategy:
+          matrix:
+            ubuntu_18:
+              imageName: 'ubuntu-18.04'
+            macOS:
+              imageName: 'macOS-10.14'
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - template: ci/tiledb-java-linux_osx.yml
+
+  - stage: BuildNativeLibs
+    condition: or(startsWith(variables['Build.SourceBranch'], 'master'), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+    jobs:
+      - job: Linux_OSX
+        strategy:
+          matrix:
+            ubuntu_18:
+              imageName: 'ubuntu-18.04'
+            macOS:
+              imageName: 'macOS-10.14'
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - template: ci/tiledb-java-linux_osx-release.yml
+      - job: Windows
+        strategy:
+          matrix:
+            windows_19:
+              imageName: 'windows-2019'
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - template: ci/tiledb-java-windows-release.yml
+
+  - stage: Release
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    jobs:
+      - job: All_OS
+        strategy:
+          matrix:
+            ubuntu_18:
+              imageName: 'ubuntu-18.04'
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - template: ci/tiledb-java-final-jar.yml

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 }
 
 task cmakeTask(type: Exec) {
+    File jniLibs = new File(buildDir.path + "/tiledb_jni")
+    File tiledbLibs = new File(buildDir.path + "/install/lib")
+
+    onlyIf { !buildDir.exists() || !jniLibs.exists() || !tiledbLibs.exists() }
     doFirst {
         mkdir buildDir
     }
@@ -75,6 +79,14 @@ task cmakeTask(type: Exec) {
 }
 
 task cmakeBuildTask(type: Exec) {
+    File jniLibs = new File(buildDir.path + "/tiledb_jni")
+    File tiledbLibs = new File(buildDir.path + "/install/lib")
+
+    onlyIf { !buildDir.exists() || !jniLibs.exists() || !tiledbLibs.exists() }
+    doFirst {
+        mkdir buildDir
+    }
+
     workingDir = buildDir
     executable = 'cmake'
     args "--build", ".", "--config", "release"
@@ -106,17 +118,20 @@ test {
 }
 
 jar {
-    into(new File('lib', osdetector.classifier).toString()) {
+    into(new File('lib').toString()) {
         // Linux and macOS
-        from file("$buildDir/install/lib/${System.mapLibraryName("tiledb")}")
-        from file("$buildDir/install/lib64/${System.mapLibraryName("tiledb")}")
-        from file("$buildDir/tiledb_jni/${System.mapLibraryName("tiledbjni")}")
-        // Windows
-        from file("$buildDir/install/bin/${System.mapLibraryName("tbb")}")
-        from file("$buildDir/install/bin/${System.mapLibraryName("tiledb")}")
-        from file("$buildDir/tiledb_jni/Release/${System.mapLibraryName("tiledbjni")}")
-    }
+        from file("$buildDir/install/lib/libtiledb.dylib")
+        from file("$buildDir/install/lib64/libtiledb.so")
+        from file("$buildDir/tiledb_jni/libtiledbjni.so")
 
+        from file("$buildDir/install/lib/libtiledb.dylib")
+        from file("$buildDir/tiledb_jni/libtiledbjni.dylib")
+
+        // Windows
+        from file("$buildDir/install/bin/tbb.dll")
+        from file("$buildDir/install/bin/tiledb.dll")
+        from file("$buildDir/tiledb_jni/Release/tiledbjni.dll")
+    }
 
     manifest {
         attributes("Implementation-Title": "Gradle",
@@ -208,6 +223,8 @@ signing {
 
 import com.github.sherter.googlejavaformatgradleplugin.GoogleJavaFormat
 import com.github.sherter.googlejavaformatgradleplugin.VerifyGoogleJavaFormat
+
+import java.nio.file.Files
 
 task format(type: GoogleJavaFormat) {
     source = sourceSets*.allJava

--- a/ci/tiledb-java-final-jar.yml
+++ b/ci/tiledb-java-final-jar.yml
@@ -1,0 +1,61 @@
+steps:
+  - download: current
+    patterns: '**/*.tar.gz'
+
+  - bash: |
+      unset SYSTEM
+      set +e
+      mv ../libraries/* .
+
+      mkdir -p ./build/install/lib
+      mkdir ./build/install/lib64
+      mkdir ./build/tiledb_jni/
+      mkdir ./build/tiledb_jni/Release
+      mkdir ./build/install/bin
+
+      for arch in $(ls | grep .tar.gz)
+      do
+        tar -xf $arch
+      done
+
+      # OSX
+      mv libtiledb.dylib ./build/install/lib
+      mv libtiledbjni.dylib ./build/tiledb_jni
+
+      # Linux
+      cp libtiledb.so ./build/install/lib
+      mv libtiledb.so ./build/install/lib64
+      mv libtiledbjni.so ./build/tiledb_jni
+
+      # Windows
+      mv tbb.dll ./build/install/bin
+      mv tiledb.dll ./build/install/bin
+      mv tiledbjni.dll ./build/tiledb_jni/Release
+
+      ./gradlew assemble
+
+      PROJECT_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+
+      cp build/libs/*.jar $BUILD_BINARIESDIRECTORY
+
+    displayName: 'Building the Fat Jar'
+
+  - bash: |
+      set -e pipefail
+      # Display log files if the build failed
+      echo "Dumping log files for failed build"
+      echo "----------------------------------"
+      for f in $(find $BUILD_REPOSITORY_LOCALPATH -name *.log);
+        do echo "------"
+           echo $f
+           echo "======"
+           cat $f
+        done;
+    condition: failed() # only run this job if the build step failed
+    displayName: "Print log files (failed build only)"
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.BinariesDirectory)
+      artifactName: final-jar
+    condition: succeeded()

--- a/ci/tiledb-java-linux_osx-release.yml
+++ b/ci/tiledb-java-linux_osx-release.yml
@@ -1,0 +1,68 @@
+steps:
+  - bash: |
+      set -e pipefail
+      open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+      sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
+    condition: eq(variables['Agent.OS'], 'Darwin')
+    displayName: 'Install system headers (OSX only)'
+
+  - bash: |
+      unset SYSTEM
+      ls
+
+      BUILD_BINARIESDIRECTORY=${BUILD_BINARIESDIRECTORY:-$BUILD_REPOSITORY_LOCALPATH/}
+
+      ./gradlew assemble
+
+      if [[ ( "$AGENT_OS" == "Linux" ) ]]; then
+            cp ./build/tiledb_jni/*.so ./build/install/lib/*.so $BUILD_BINARIESDIRECTORY
+      fi
+
+      if [[ ( "$AGENT_OS" == "Darwin" ) ]]; then
+              cp ./build/tiledb_jni/*.dylib ./build/install/lib/*.dylib $BUILD_BINARIESDIRECTORY
+      fi
+
+      echo "Native Libs"
+      ls $BUILD_BINARIESDIRECTORY
+
+    displayName: 'Build and Upload (Ubuntu and OSX)'
+
+  - bash: |
+      set -e pipefail
+      # Display log files if the build failed
+      echo "Dumping log files for failed build"
+      echo "----------------------------------"
+      for f in $(find $BUILD_REPOSITORY_LOCALPATH -name *.log);
+        do echo "------"
+           echo $f
+           echo "======"
+           cat $f
+        done;
+    condition: failed() # only run this job if the build step failed
+    displayName: "Print log files (failed build only)"
+
+
+  - script: |
+      echo $sourceVersion
+      commitHash=${sourceVersion:0:7}
+      echo $commitHash
+      echo "##vso[task.setvariable variable=commitHash]$commitHash" ## Set variable for using in other tasks.
+    env: { sourceVersion: $(Build.SourceVersion) }
+    displayName: Git Hash 7-digit
+
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: '$(Build.BinariesDirectory)'
+      includeRootFolder: false
+      archiveType: 'tar' # Options: zip, 7z, tar, wim
+      tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
+      archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(Agent.OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz
+      replaceExistingArchive: true
+      verbose: true # Optional
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.ArtifactStagingDirectory)/tiledb-$(Agent.OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz
+      artifactName: libraries
+    condition: succeeded()

--- a/ci/tiledb-java-linux_osx.yml
+++ b/ci/tiledb-java-linux_osx.yml
@@ -1,18 +1,27 @@
 steps:
   - bash: |
+      unset SYSTEM
       set -e pipefail
       open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
       sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
     condition: eq(variables['Agent.OS'], 'Darwin')
     displayName: 'Install system headers (OSX only)'
 
+
   - bash: |
       unset SYSTEM
-      ls
-      ./gradlew assemble
       ./gradlew checkFormat
+    displayName: 'Check Format'
+
+  - bash: |
+      unset SYSTEM
+      ./gradlew assemble
+    displayName: 'Assemble'
+
+  - bash: |
+      unset SYSTEM
       ./gradlew test
-    displayName: 'Build and Test (Ubuntu and OSX)'
+    displayName: 'Test'
 
   - bash: |
       set -e pipefail

--- a/ci/tiledb-java-windows-release.yml
+++ b/ci/tiledb-java-windows-release.yml
@@ -1,0 +1,49 @@
+steps:
+
+  - bash: |
+      ls
+      cp *.dll $BUILD_BINARIESDIRECTORY
+      ./gradlew.bat assemble
+      cp ./build/tiledb_jni/Release/*.dll ./build/install/bin/*.dll $BUILD_BINARIESDIRECTORY
+
+    displayName: 'Build and Upload (Windows)'
+
+  - bash: |
+      set -e pipefail
+      # Display log files if the build failed
+      echo "Dumping log files for failed build"
+      echo "----------------------------------"
+      for f in $(find $BUILD_REPOSITORY_LOCALPATH -name *.log);
+        do echo "------"
+           echo $f
+           echo "======"
+           cat $f
+        done;
+    condition: failed() # only run this job if the build step failed
+    displayName: "Print log files (failed build only)"
+
+
+  - bash: |
+      echo $sourceVersion
+      commitHash=${sourceVersion:0:7}
+      echo $commitHash
+      echo "##vso[task.setvariable variable=commitHash]$commitHash" ## Set variable for using in other tasks.
+    env: { sourceVersion: $(Build.SourceVersion) }
+    displayName: Git Hash 7-digit
+
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: '$(Build.BinariesDirectory)'
+      includeRootFolder: false
+      archiveType: 'tar' # Options: zip, 7z, tar, wim
+      tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
+      archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(Agent.OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz
+      replaceExistingArchive: true
+      verbose: true # Optional
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.ArtifactStagingDirectory)/tiledb-$(Agent.OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz
+      artifactName: libraries
+    condition: succeeded()

--- a/src/main/java/io/tiledb/libtiledb/NativeLibLoader.java
+++ b/src/main/java/io/tiledb/libtiledb/NativeLibLoader.java
@@ -317,7 +317,7 @@ public class NativeLibLoader {
    */
   private static Path findNativeLibrary(String libraryName, boolean mapLibraryName) {
     String mappedLibraryName = mapLibraryName ? System.mapLibraryName(libraryName) : libraryName;
-    String libDir = LIB_RESOURCE_DIR + "/" + getOSClassifier();
+    String libDir = LIB_RESOURCE_DIR;
     String libPath = libDir + "/" + mappedLibraryName;
 
     boolean hasNativeLib = hasResource(libPath);


### PR DESCRIPTION
In this PR we added stages in Azure Pipelines. The following were added
- Build the native libraries of OSX, Linux and Windows and publish them as artifacts in Azure Pipelines
- Build a fat jar that contains all native libraries