### PR TITLE
NIO ByteBuffer support for variable-sized attributes

### DIFF
--- a/src/main/c/generated/tiledb_wrap.cxx
+++ b/src/main/c/generated/tiledb_wrap.cxx
@@ -7075,6 +7075,39 @@ SWIGEXPORT jint JNICALL Java_io_tiledb_libtiledb_tiledbJNI_tiledb_1query_1set_1b
   return jresult;
 }
 
+SWIGEXPORT jint JNICALL Java_io_tiledb_libtiledb_tiledbJNI_tiledb_1query_1set_1buffer_1var_1nio(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2, jstring jarg3, jobject jarg4, jlong jarg5, jobject jarg6, jlong jarg7) {
+  void* offsets = (void *)jenv->GetDirectBufferAddress(jarg4);
+  void* buffer = (void *)jenv->GetDirectBufferAddress(jarg6);
+
+  jint jresult = 0 ;
+  tiledb_ctx_t *arg1 = (tiledb_ctx_t *) 0 ;
+  tiledb_query_t *arg2 = (tiledb_query_t *) 0 ;
+  char *arg3 = (char *) 0 ;
+  uint64_t *arg4 = (uint64_t *) 0 ;
+  uint64_t *arg5 = (uint64_t *) 0 ;
+  void *arg6 = (void *) 0 ;
+  uint64_t *arg7 = (uint64_t *) 0 ;
+  int32_t result;
+
+  (void)jenv;
+  (void)jcls;
+  arg1 = *(tiledb_ctx_t **)&jarg1;
+  arg2 = *(tiledb_query_t **)&jarg2;
+  arg3 = 0;
+  if (jarg3) {
+    arg3 = (char *)jenv->GetStringUTFChars(jarg3, 0);
+    if (!arg3) return 0;
+  }
+  arg4 = *(uint64_t **)&jarg4;
+  arg5 = *(uint64_t **)&jarg5;
+  arg6 = *(void **)&jarg6;
+  arg7 = *(uint64_t **)&jarg7;
+  result = (int32_t)tiledb_query_set_buffer_var(arg1,arg2,(char const *)arg3,(uint64_t *)offsets,arg5,buffer,arg7);
+  jresult = (jint)result;
+  if (arg3) jenv->ReleaseStringUTFChars(jarg3, (const char *)arg3);
+  return jresult;
+}
+
 
 SWIGEXPORT jint JNICALL Java_io_tiledb_libtiledb_tiledbJNI_tiledb_1query_1get_1buffer(JNIEnv *jenv, jclass jcls, jlong jarg1, jlong jarg2, jstring jarg3, jlong jarg4, jlong jarg5) {
   jint jresult = 0 ;

--- a/src/main/java/io/tiledb/java/api/Query.java
+++ b/src/main/java/io/tiledb/java/api/Query.java
@@ -496,7 +496,7 @@ public class Query implements AutoCloseable {
    * @return The NIO ByteBuffer
    * @throws TileDBError
    */
-  public synchronized ByteBuffer setBuffer(String attr, long bufferElements) throws TileDBError {
+  public synchronized Query setBuffer(String attr, long bufferElements) throws TileDBError {
     if (bufferElements <= 0) {
       throw new TileDBError("Number of buffer elements must be >= 1");
     }
@@ -521,7 +521,7 @@ public class Query implements AutoCloseable {
 
     this.setBuffer(attr, buffer);
 
-    return buffer;
+    return this;
   }
 
   /**
@@ -532,7 +532,7 @@ public class Query implements AutoCloseable {
    * @return The NIO ByteBuffer
    * @throws TileDBError
    */
-  public synchronized ByteBuffer setBuffer(String attr, ByteBuffer buffer) throws TileDBError {
+  public synchronized Query setBuffer(String attr, ByteBuffer buffer) throws TileDBError {
     if (buffer.capacity() <= 0) {
       throw new TileDBError("Number of buffer elements must be >= 1");
     }
@@ -566,7 +566,7 @@ public class Query implements AutoCloseable {
         tiledb.tiledb_query_set_buffer_nio(
             ctx.getCtxp(), queryp, attr, buffer, values_array_size.cast()));
 
-    return buffer;
+    return this;
   }
 
   /**
@@ -1054,8 +1054,10 @@ public class Query implements AutoCloseable {
    * @return The ByteBuffer
    * @throws TileDBError A TileDB exception
    */
-  public ByteBuffer getByteBuffer(String attr) throws TileDBError {
-    if (byteBuffers_.containsKey(attr)) return byteBuffers_.get(attr);
+  public Pair<ByteBuffer, ByteBuffer> getByteBuffer(String attr) throws TileDBError {
+    if (byteBuffers_.containsKey(attr)) return new Pair(null, byteBuffers_.get(attr));
+    else if (varByteBuffers_.containsKey(attr))
+      return new Pair(varByteBuffers_.get(attr).getFirst(), varByteBuffers_.get(attr).getSecond());
     else throw new TileDBError("ByteBuffer does not exist for attribute: " + attr);
   }
 

--- a/src/main/java/io/tiledb/java/api/Query.java
+++ b/src/main/java/io/tiledb/java/api/Query.java
@@ -526,7 +526,8 @@ public class Query implements AutoCloseable {
 
     int size = Util.castLongToInt(bufferElements * dt.getNativeSize());
 
-    ByteBuffer buffer = ByteBuffer.allocateDirect(size);
+    ByteBuffer buffer = ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder());
+    ;
 
     this.setBuffer(attr, buffer);
 
@@ -551,14 +552,9 @@ public class Query implements AutoCloseable {
           "The ByteBuffer provided is not direct. Please provide a direct buffer (ByteBuffer.allocateDirect(...))");
     }
 
-    if (!buffer.order().equals(ByteOrder.nativeOrder()) && buffer.position() > 0) {
-      throw new TileDBError(
-          "The order of the data ByteBuffer should be the same as the native order (ByteOrder.nativeOrder()) before values are inserted.");
-    }
-
     if (!buffer.order().equals(ByteOrder.nativeOrder())) {
-      // TODO: Add a logger component to Query class and a WARN here
-      buffer.order(ByteOrder.nativeOrder());
+      throw new TileDBError(
+          "The order of the data ByteBuffer should be the same as the native order (ByteOrder.nativeOrder()).");
     }
 
     this.byteBuffers_.put(attr, new Pair<>(null, buffer));

--- a/src/main/java/io/tiledb/libtiledb/tiledb.java
+++ b/src/main/java/io/tiledb/libtiledb/tiledb.java
@@ -2165,6 +2165,24 @@ public class tiledb implements tiledbConstants {
         SWIGTYPE_p_unsigned_long_long.getCPtr(buffer_val_size));
   }
 
+  public static int tiledb_query_set_buffer_var_nio(
+      SWIGTYPE_p_tiledb_ctx_t ctx,
+      SWIGTYPE_p_tiledb_query_t query,
+      String name,
+      ByteBuffer buffer_off,
+      SWIGTYPE_p_unsigned_long_long buffer_off_size,
+      ByteBuffer buffer_val,
+      SWIGTYPE_p_unsigned_long_long buffer_val_size) {
+    return tiledbJNI.tiledb_query_set_buffer_var_nio(
+        SWIGTYPE_p_tiledb_ctx_t.getCPtr(ctx),
+        SWIGTYPE_p_tiledb_query_t.getCPtr(query),
+        name,
+        buffer_off,
+        SWIGTYPE_p_unsigned_long_long.getCPtr(buffer_off_size),
+        buffer_val,
+        SWIGTYPE_p_unsigned_long_long.getCPtr(buffer_val_size));
+  }
+
   public static int tiledb_query_get_buffer(
       SWIGTYPE_p_tiledb_ctx_t ctx,
       SWIGTYPE_p_tiledb_query_t query,

--- a/src/main/java/io/tiledb/libtiledb/tiledbJNI.java
+++ b/src/main/java/io/tiledb/libtiledb/tiledbJNI.java
@@ -928,6 +928,15 @@ public class tiledbJNI {
   public static final native int tiledb_query_set_buffer_var(
       long jarg1, long jarg2, String jarg3, long jarg4, long jarg5, long jarg6, long jarg7);
 
+  public static final native int tiledb_query_set_buffer_var_nio(
+      long jarg1,
+      long jarg2,
+      String jarg3,
+      ByteBuffer jarg4,
+      long jarg5,
+      ByteBuffer jarg6,
+      long jarg7);
+
   public static final native int tiledb_query_get_buffer(
       long jarg1, long jarg2, String jarg3, long jarg4, long jarg5);
 

--- a/src/test/java/io/tiledb/java/api/QueryTest.java
+++ b/src/test/java/io/tiledb/java/api/QueryTest.java
@@ -314,8 +314,10 @@ public class QueryTest {
 
       int bufferSize = 4;
 
-      ByteBuffer d1 = query.setBuffer("rows", bufferSize);
-      ByteBuffer d2 = query.setBuffer("cols", bufferSize);
+      query.setBuffer("rows", bufferSize);
+      query.setBuffer("cols", bufferSize);
+      ByteBuffer d1 = query.getByteBuffer("rows").getSecond();
+      ByteBuffer d2 = query.getByteBuffer("cols").getSecond();
 
       query.addRange(0, 1, 4);
       query.addRange(1, 1, 4);
@@ -354,9 +356,10 @@ public class QueryTest {
       Query query = new Query(array, TILEDB_READ);
 
       int bufferSize = 4;
-
-      ByteBuffer d1 = query.setBuffer("rows", ByteBuffer.allocateDirect(10));
-      ByteBuffer d2 = query.setBuffer("cols", ByteBuffer.allocateDirect(10));
+      query.setBuffer("rows", ByteBuffer.allocateDirect(10));
+      query.setBuffer("cols", ByteBuffer.allocateDirect(10));
+      ByteBuffer d1 = query.getByteBuffer("rows").getSecond();
+      ByteBuffer d2 = query.getByteBuffer("cols").getSecond();
 
       query.addRange(0, 1, 4);
       query.addRange(1, 1, 4);
@@ -399,10 +402,12 @@ public class QueryTest {
         query.addRange(1, 2, 4);
         query.setLayout(TILEDB_ROW_MAJOR);
 
-        ByteBuffer dim1Buffer = query.setBuffer("rows", 3);
-        ByteBuffer dim2Buffer = query.setBuffer("cols", 3);
-        ByteBuffer a1Buffer = query.setBuffer("a1", 3);
-        ByteBuffer a2Buffer = query.setBuffer("a2", 6);
+        query.setBuffer("rows", 3).setBuffer("cols", 3).setBuffer("a1", 3).setBuffer("a2", 6);
+
+        ByteBuffer dim1Buffer = query.getByteBuffer("rows").getSecond();
+        ByteBuffer dim2Buffer = query.getByteBuffer("cols").getSecond();
+        ByteBuffer a1Buffer = query.getByteBuffer("a1").getSecond();
+        ByteBuffer a2Buffer = query.getByteBuffer("a2").getSecond();
 
         // Submit query
         query.submit();
@@ -459,12 +464,16 @@ public class QueryTest {
                 ? ByteOrder.LITTLE_ENDIAN
                 : ByteOrder.BIG_ENDIAN;
 
-        ByteBuffer dim1Buffer =
-            query.setBuffer("rows", ByteBuffer.allocateDirect(3 * 4).order(order));
-        ByteBuffer dim2Buffer =
-            query.setBuffer("cols", ByteBuffer.allocateDirect(3 * 4).order(order));
-        ByteBuffer a1Buffer = query.setBuffer("a1", ByteBuffer.allocateDirect(3).order(order));
-        ByteBuffer a2Buffer = query.setBuffer("a2", ByteBuffer.allocateDirect(6 * 4).order(order));
+        query
+            .setBuffer("rows", ByteBuffer.allocateDirect(3 * 4).order(order))
+            .setBuffer("cols", ByteBuffer.allocateDirect(3 * 4).order(order))
+            .setBuffer("a1", ByteBuffer.allocateDirect(3).order(order))
+            .setBuffer("a2", ByteBuffer.allocateDirect(6 * 4).order(order));
+
+        ByteBuffer dim1Buffer = query.getByteBuffer("rows").getSecond();
+        ByteBuffer dim2Buffer = query.getByteBuffer("cols").getSecond();
+        ByteBuffer a1Buffer = query.getByteBuffer("a1").getSecond();
+        ByteBuffer a2Buffer = query.getByteBuffer("a2").getSecond();
 
         // Submit query
         query.submit();
@@ -514,9 +523,9 @@ public class QueryTest {
 
       query.setBuffer("rows", bufferSize);
 
-      Assert.assertEquals(query.getByteBuffer("rows").capacity(), bufferSize * 4);
-      Assert.assertTrue(query.getByteBuffer("rows").isDirect());
-      Assert.assertEquals(query.getByteBuffer("rows").order(), ByteOrder.nativeOrder());
+      Assert.assertEquals(query.getByteBuffer("rows").getSecond().capacity(), bufferSize * 4);
+      Assert.assertTrue(query.getByteBuffer("rows").getSecond().isDirect());
+      Assert.assertEquals(query.getByteBuffer("rows").getSecond().order(), ByteOrder.nativeOrder());
     }
 
     @Test()
@@ -544,7 +553,8 @@ public class QueryTest {
               : ByteOrder.BIG_ENDIAN;
 
       // The Byte Order should be automatically changed to the native order
-      ByteBuffer b = query.setBuffer("rows", ByteBuffer.allocateDirect(bufferSize).order(order));
+      query.setBuffer("rows", ByteBuffer.allocateDirect(bufferSize).order(order));
+      ByteBuffer b = query.getByteBuffer("rows").getSecond();
       Assert.assertEquals(b.order(), ByteOrder.nativeOrder());
     }
 
@@ -566,10 +576,12 @@ public class QueryTest {
 
       int idx = 0;
 
-      while (offsetsBuffer.hasRemaining()) offsets[idx++] = offsetsBuffer.getLong();
+      while (q.getByteBuffer("a1").getFirst().hasRemaining())
+        offsets[idx++] = offsetsBuffer.getLong();
 
       idx = 0;
-      while (dataBuffer.hasRemaining()) data[idx++] = (char) dataBuffer.get();
+      while (q.getByteBuffer("a1").getSecond().hasRemaining())
+        data[idx++] = (char) dataBuffer.get();
 
       Assert.assertArrayEquals(new long[] {0, 2, 4, 6, 8, 10, 12, 14}, offsets);
       Assert.assertEquals("aabbccddeeffgghh", new String(data));

--- a/src/test/java/io/tiledb/java/api/QueryTest.java
+++ b/src/test/java/io/tiledb/java/api/QueryTest.java
@@ -356,8 +356,8 @@ public class QueryTest {
       Query query = new Query(array, TILEDB_READ);
 
       int bufferSize = 4;
-      query.setBuffer("rows", ByteBuffer.allocateDirect(10));
-      query.setBuffer("cols", ByteBuffer.allocateDirect(10));
+      query.setBuffer("rows", ByteBuffer.allocateDirect(10).order(ByteOrder.nativeOrder()));
+      query.setBuffer("cols", ByteBuffer.allocateDirect(10).order(ByteOrder.nativeOrder()));
       ByteBuffer d1 = query.getByteBuffer("rows").getSecond();
       ByteBuffer d2 = query.getByteBuffer("cols").getSecond();
 
@@ -444,7 +444,7 @@ public class QueryTest {
       }
     }
 
-    @Test
+    @Test(expected = TileDBError.class)
     public void arrayReadTestCustomBufferWithDifferentOrder() throws Exception {
       arrayCreate();
       arrayWrite();
@@ -464,49 +464,7 @@ public class QueryTest {
                 ? ByteOrder.LITTLE_ENDIAN
                 : ByteOrder.BIG_ENDIAN;
 
-        query
-            .setBuffer("rows", ByteBuffer.allocateDirect(3 * 4).order(order))
-            .setBuffer("cols", ByteBuffer.allocateDirect(3 * 4).order(order))
-            .setBuffer("a1", ByteBuffer.allocateDirect(3).order(order))
-            .setBuffer("a2", ByteBuffer.allocateDirect(6 * 4).order(order));
-
-        ByteBuffer dim1Buffer = query.getByteBuffer("rows").getSecond();
-        ByteBuffer dim2Buffer = query.getByteBuffer("cols").getSecond();
-        ByteBuffer a1Buffer = query.getByteBuffer("a1").getSecond();
-        ByteBuffer a2Buffer = query.getByteBuffer("a2").getSecond();
-
-        // Submit query
-        query.submit();
-
-        int[] dim1 = new int[3];
-        int[] dim2 = new int[3];
-        byte[] a1 = new byte[3];
-        float[] a2 = new float[6];
-
-        int idx = 0;
-        while (dim1Buffer.hasRemaining()) {
-          dim1[idx++] = dim1Buffer.getInt();
-        }
-
-        idx = 0;
-        while (dim2Buffer.hasRemaining()) {
-          dim2[idx++] = dim2Buffer.getInt();
-        }
-
-        idx = 0;
-        while (a1Buffer.hasRemaining()) {
-          a1[idx++] = a1Buffer.get();
-        }
-
-        idx = 0;
-        while (a2Buffer.hasRemaining()) {
-          a2[idx++] = a2Buffer.getFloat();
-        }
-
-        Assert.assertArrayEquals(new int[] {1, 1, 1}, dim1);
-        Assert.assertArrayEquals(new int[] {2, 3, 4}, dim2);
-        Assert.assertArrayEquals(new byte[] {'b', 'c', 'd'}, a1);
-        Assert.assertArrayEquals(new float[] {1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f}, a2, 0.01f);
+        query.setBuffer("rows", ByteBuffer.allocateDirect(3 * 4).order(order));
       }
     }
 
@@ -528,7 +486,7 @@ public class QueryTest {
       Assert.assertEquals(query.getByteBuffer("rows").getSecond().order(), ByteOrder.nativeOrder());
     }
 
-    @Test()
+    @Test(expected = TileDBError.class)
     public void queryTestNIOGetByteBuffeErrors() throws Exception {
       arrayCreate();
       arrayWrite();
@@ -554,8 +512,6 @@ public class QueryTest {
 
       // The Byte Order should be automatically changed to the native order
       query.setBuffer("rows", ByteBuffer.allocateDirect(bufferSize).order(order));
-      ByteBuffer b = query.getByteBuffer("rows").getSecond();
-      Assert.assertEquals(b.order(), ByteOrder.nativeOrder());
     }
 
     @Test()


### PR DESCRIPTION
This PR includes the following:
1. Added `ByteBuffer` support for var-sized attributes/dimensions
2. Changed `setBuffer` method to return the `Query` instance instead of the `ByteBuffer`.