### PR TITLE
Datatype-specific methods for ByteBuffer manipulation

### DIFF
--- a/src/main/java/io/tiledb/java/api/Datatype.java
+++ b/src/main/java/io/tiledb/java/api/Datatype.java
@@ -124,7 +124,7 @@ public enum Datatype {
       case TILEDB_FLOAT64:
         return Double.class;
       case TILEDB_CHAR:
-        return Short.class;
+        return Byte.class;
       case TILEDB_INT8:
         return Byte.class;
       case TILEDB_UINT8:

--- a/src/main/java/io/tiledb/java/api/Util.java
+++ b/src/main/java/io/tiledb/java/api/Util.java
@@ -36,4 +36,29 @@ public class Util {
 
     return (int) num;
   }
+
+  /**
+   * Returns the Datatype of the input field
+   *
+   * @param array The TileDB array
+   * @param fieldName The field name
+   * @return The Datatype
+   * @throws TileDBError A TileDBError
+   */
+  public static Datatype getFieldDatatype(Array array, String fieldName) throws TileDBError {
+    Datatype dt;
+    try (ArraySchema schema = array.getSchema()) {
+      try (Domain domain = schema.getDomain()) {
+        if (domain.hasDimension(fieldName)) {
+          dt = domain.getDimension(fieldName).getType();
+        } else {
+          try (Attribute attribute = schema.getAttribute(fieldName)) {
+            dt = attribute.getType();
+          }
+        }
+      }
+    }
+
+    return dt;
+  }
 }


### PR DESCRIPTION
This PR contains some additional methods in the `Query` class for manipulating NIO `ByteBuffers` of specific datatypes, like `getCharBuffer`, `getIntegerBuffer` or `getShortBuffer`. 