### PR TITLE
Switch to Ubuntu 16.04 based build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,8 @@ stages:
       - job: Linux_OSX
         strategy:
           matrix:
-            ubuntu_18:
-              imageName: 'ubuntu-18.04'
+            ubuntu_16:
+              imageName: 'ubuntu-16.04'
               ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: "OFF"
               ORG_GRADLE_PROJECT_TILEDB_S3: "OFF"
             macOS:
@@ -57,8 +57,8 @@ stages:
       - job: Linux_OSX
         strategy:
           matrix:
-            ubuntu_18:
-              imageName: 'ubuntu-18.04'
+            ubuntu_16:
+              imageName: 'ubuntu-16.04'
               ORG_GRADLE_PROJECT_TILEDB_S3: "ON"
               ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: "ON"
             macOS:
@@ -86,8 +86,8 @@ stages:
       - job: All_OS
         strategy:
           matrix:
-            ubuntu_18:
-              imageName: 'ubuntu-18.04'
+            ubuntu_16:
+              imageName: 'ubuntu-16.04'
               ORG_GRADLE_PROJECT_TILEDB_S3: "ON"
               ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: "ON"
         pool:
@@ -148,8 +148,8 @@ stages:
       - job: All_OS
         strategy:
           matrix:
-            ubuntu_18:
-              imageName: 'ubuntu-18.04'
+            ubuntu_16:
+              imageName: 'ubuntu-16.04'
         pool:
           vmImage: $(imageName)
         steps:


### PR DESCRIPTION
During work on adding TileDB support to `bioformats2raw` in glencoesoftware/bioformats2raw#57 glibc and libstdc++ missing symbols were noticed in the native code. This was on CentOS 7 which is both our most common deployment platform and the most common Linux distribution in use on the HPC platforms we interact with.

Building on Ubuntu 16.04 should mean that CentOS 7 is supported. This does not go as far as TileDB-Py which currently targets CentOS 6 via the use of the `manylinux2010` [1] for its binary wheels and by extension supports back to CentOS 6.

1. https://github.com/TileDB-Inc/TileDB-Py/blob/dev/HISTORY.md#tiledb-py-066-release-notes
