### PR TITLE
Also support the multilib (lib64) output directory

### DIFF
--- a/ci/tiledb-java-linux_osx-release.yml
+++ b/ci/tiledb-java-linux_osx-release.yml
@@ -15,7 +15,7 @@ steps:
       if [[ ( "$AGENT_OS" == "Linux" ) ]]; then
         docker build -f ci/Dockerfile2010 . -t lib_builder_2010
         docker run -v $(pwd):/TileDB-Java -t lib_builder_2010 /TileDB-Java/ci/build.sh
-        cp ./build/tiledb_jni/*.so ./build/install/lib/*.so $BUILD_BINARIESDIRECTORY
+        cp ./build/tiledb_jni/*.so ./build/install/lib/*.so ./build/install/lib64/*.so $BUILD_BINARIESDIRECTORY
       fi
 
       if [[ ( "$AGENT_OS" == "Darwin" ) ]]; then


### PR DESCRIPTION
Artifacts from the native build may end up in a multilib output directory location:

```
callan@behemoth:~/code/TileDB-Java$ find build -name '*.so'
build/ep_tiledb-prefix/src/ep_tiledb-build/externals/src/ep_zlib-build/libz.so
build/ep_tiledb-prefix/src/ep_tiledb-build/externals/src/ep_zstd-build/lib/libzstd.so
build/ep_tiledb-prefix/src/ep_tiledb-build/externals/install/lib/libz.so
build/ep_tiledb-prefix/src/ep_tiledb-build/externals/install/lib64/libzstd.so
build/ep_tiledb-prefix/src/ep_tiledb-build/tiledb/tiledb/libtiledb.so
build/tiledb_jni/libtiledbjni.so
build/install/lib64/libtiledb.so
```

Also need to support that or certain dynamic libraries will not end up in the resulting JAR.