### PR TITLE
Support some more string encodings; UTF-8 in particular

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,9 @@ task generateJNI(type: Exec) {
     executable = "../generate_tiledb_jni"
 }
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
 import org.apache.tools.ant.taskdefs.condition.Os
 test {
     useJUnit()

--- a/src/main/java/io/tiledb/java/api/NativeArray.java
+++ b/src/main/java/io/tiledb/java/api/NativeArray.java
@@ -197,13 +197,13 @@ public class NativeArray implements AutoCloseable {
         {
           return ((long[]) buffer).length;
         }
+      case TILEDB_CHAR:
       case TILEDB_STRING_ASCII:
         {
           Charset charset = StandardCharsets.ISO_8859_1;
           return stringToBytes((String) buffer, charset).length;
         }
       case TILEDB_STRING_UTF8:
-      case TILEDB_CHAR:
         {
           Charset charset = StandardCharsets.UTF_8;
           return stringToBytes((String) buffer, charset).length;
@@ -283,6 +283,7 @@ public class NativeArray implements AutoCloseable {
           uint64_tArray = Utils.newInt64_tArray((long[]) buffer);
           break;
         }
+      case TILEDB_CHAR:
       case TILEDB_STRING_ASCII:
         {
           Charset charset = StandardCharsets.ISO_8859_1;
@@ -290,7 +291,6 @@ public class NativeArray implements AutoCloseable {
           break;
         }
       case TILEDB_STRING_UTF8:
-      case TILEDB_CHAR:
         {
           Charset charset = StandardCharsets.UTF_8;
           int8_tArray = Utils.newInt8_tArray(stringToBytes((String) buffer, charset));
@@ -544,6 +544,7 @@ public class NativeArray implements AutoCloseable {
           uint64_tArray.setitem(index, (long) value);
           break;
         }
+      case TILEDB_CHAR:
       case TILEDB_STRING_ASCII:
         {
           Charset charset = StandardCharsets.ISO_8859_1;
@@ -554,7 +555,6 @@ public class NativeArray implements AutoCloseable {
           break;
         }
       case TILEDB_STRING_UTF8:
-      case TILEDB_CHAR:
         {
           Charset charset = StandardCharsets.UTF_8;
           for (byte b : stringToBytes((String) value, charset)) {

--- a/src/main/java/io/tiledb/java/api/NativeArray.java
+++ b/src/main/java/io/tiledb/java/api/NativeArray.java
@@ -33,6 +33,7 @@
 package io.tiledb.java.api;
 
 import io.tiledb.libtiledb.*;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class NativeArray implements AutoCloseable {
@@ -197,9 +198,15 @@ public class NativeArray implements AutoCloseable {
           return ((long[]) buffer).length;
         }
       case TILEDB_STRING_ASCII:
+        {
+          Charset charset = StandardCharsets.ISO_8859_1;
+          return stringToBytes((String) buffer, charset).length;
+        }
+      case TILEDB_STRING_UTF8:
       case TILEDB_CHAR:
         {
-          return stringToBytes(buffer).length;
+          Charset charset = StandardCharsets.UTF_8;
+          return stringToBytes((String) buffer, charset).length;
         }
       case TILEDB_DATETIME_YEAR:
       case TILEDB_DATETIME_MONTH:
@@ -277,10 +284,16 @@ public class NativeArray implements AutoCloseable {
           break;
         }
       case TILEDB_STRING_ASCII:
+        {
+          Charset charset = StandardCharsets.ISO_8859_1;
+          int8_tArray = Utils.newInt8_tArray(stringToBytes((String) buffer, charset));
+          break;
+        }
+      case TILEDB_STRING_UTF8:
       case TILEDB_CHAR:
         {
-          byte[] bytes = stringToBytes(buffer);
-          int8_tArray = Utils.newInt8_tArray(bytes);
+          Charset charset = StandardCharsets.UTF_8;
+          int8_tArray = Utils.newInt8_tArray(stringToBytes((String) buffer, charset));
           break;
         }
       case TILEDB_DATETIME_YEAR:
@@ -532,9 +545,19 @@ public class NativeArray implements AutoCloseable {
           break;
         }
       case TILEDB_STRING_ASCII:
+        {
+          Charset charset = StandardCharsets.ISO_8859_1;
+          for (byte b : stringToBytes((String) value, charset)) {
+            int8_tArray.setitem(index, b);
+            index++;
+          }
+          break;
+        }
+      case TILEDB_STRING_UTF8:
       case TILEDB_CHAR:
         {
-          for (byte b : stringToBytes(value)) {
+          Charset charset = StandardCharsets.UTF_8;
+          for (byte b : stringToBytes((String) value, charset)) {
             int8_tArray.setitem(index, b);
             index++;
           }
@@ -607,6 +630,7 @@ public class NativeArray implements AutoCloseable {
           return PointerUtils.toVoid(uint64_tArray);
         }
       case TILEDB_STRING_ASCII:
+      case TILEDB_STRING_UTF8:
       case TILEDB_CHAR:
         {
           return PointerUtils.toVoid(int8_tArray);
@@ -778,6 +802,7 @@ public class NativeArray implements AutoCloseable {
           return Utils.int64ArrayGet(uint64_tArray, position, elements);
         }
       case TILEDB_STRING_ASCII:
+      case TILEDB_STRING_UTF8:
       case TILEDB_CHAR:
         {
           return Utils.int8ArrayGet(int8_tArray, position, elements);
@@ -872,6 +897,8 @@ public class NativeArray implements AutoCloseable {
           int64_tArray = PointerUtils.int64_tArrayFromVoid(pointer);
           break;
         }
+      case TILEDB_STRING_ASCII:
+      case TILEDB_STRING_UTF8:
       case TILEDB_CHAR:
         {
           int8_tArray = PointerUtils.int8_tArrayFromVoid(pointer);
@@ -959,8 +986,8 @@ public class NativeArray implements AutoCloseable {
     }
   }
 
-  private byte[] stringToBytes(Object buffer) {
-    return ((String) buffer).getBytes(StandardCharsets.UTF_8);
+  private byte[] stringToBytes(String buffer, Charset charset) {
+    return buffer.getBytes(charset);
   }
 
   protected Datatype getNativeType() {

--- a/src/main/java/io/tiledb/java/api/Types.java
+++ b/src/main/java/io/tiledb/java/api/Types.java
@@ -111,6 +111,7 @@ public class Types {
         {
           return Long.class;
         }
+      case TILEDB_STRING_UTF8:
       case TILEDB_STRING_ASCII:
       case TILEDB_CHAR:
         {

--- a/src/test/java/io/tiledb/java/api/ArrayTest.java
+++ b/src/test/java/io/tiledb/java/api/ArrayTest.java
@@ -425,6 +425,8 @@ public class ArrayTest {
             Double.class);
 
     NativeArray metadataString = new NativeArray(ctx, "русский", String.class);
+    NativeArray metadataStringAscii = new NativeArray(ctx, "Russia", TILEDB_STRING_ASCII);
+    NativeArray metadataStringUtf8 = new NativeArray(ctx, "русский", TILEDB_STRING_UTF8);
 
     String byteKey = "md-byte";
     String shortKey = "md-short";
@@ -432,17 +434,36 @@ public class ArrayTest {
     String floatKey = "md-float";
     String doubleKey = "md-double";
     String stringKey = "md-string";
+    String stringAsciiKey = "md-string-ascii";
+    String stringUtf8Key = "md-string-utf8";
 
     // metadata keys sorted in a lexicographic ordering
-    String[] keys = new String[] {byteKey, doubleKey, floatKey, intKey, shortKey, stringKey};
+    String[] keys =
+        new String[] {
+          byteKey, doubleKey, floatKey, intKey, shortKey, stringKey, stringAsciiKey, stringUtf8Key
+        };
     Datatype[] types =
         new Datatype[] {
-          TILEDB_INT8, TILEDB_FLOAT64, TILEDB_FLOAT32, TILEDB_INT32, TILEDB_INT16, TILEDB_CHAR
+          TILEDB_INT8,
+          TILEDB_FLOAT64,
+          TILEDB_FLOAT32,
+          TILEDB_INT32,
+          TILEDB_INT16,
+          TILEDB_CHAR,
+          TILEDB_STRING_ASCII,
+          TILEDB_STRING_UTF8
         };
     int keysNum = keys.length;
     NativeArray[] nativeArrays =
         new NativeArray[] {
-          metadataByte, metadataDouble, metadataFloat, metadataInt, metadataShort, metadataString
+          metadataByte,
+          metadataDouble,
+          metadataFloat,
+          metadataInt,
+          metadataShort,
+          metadataString,
+          metadataStringAscii,
+          metadataStringUtf8
         };
     Object[] expectedArrays =
         new Object[] {
@@ -451,7 +472,9 @@ public class ArrayTest {
           metadataFloat.toJavaArray(),
           metadataInt.toJavaArray(),
           metadataShort.toJavaArray(),
-          metadataString.toJavaArray()
+          metadataString.toJavaArray(),
+          metadataStringAscii.toJavaArray(),
+          metadataStringUtf8.toJavaArray()
         };
 
     for (int i = 0; i < keysNum; i++) {
@@ -483,6 +506,8 @@ public class ArrayTest {
     NativeArray metadataFloatActual = arrayn.getMetadata(floatKey, TILEDB_FLOAT32);
     NativeArray metadataDoubleActual = arrayn.getMetadata(doubleKey, TILEDB_FLOAT64);
     NativeArray metadataStringActual = arrayn.getMetadata(stringKey, TILEDB_CHAR);
+    NativeArray metadataStringAsciiActual = arrayn.getMetadata(stringAsciiKey, TILEDB_STRING_ASCII);
+    NativeArray metadataStringUtf8Actual = arrayn.getMetadata(stringUtf8Key, TILEDB_STRING_UTF8);
 
     Assert.assertNotNull(metadataByteActual);
     Assert.assertNotNull(metadataShortActual);
@@ -490,6 +515,8 @@ public class ArrayTest {
     Assert.assertNotNull(metadataFloatActual);
     Assert.assertNotNull(metadataDoubleActual);
     Assert.assertNotNull(metadataStringActual);
+    Assert.assertNotNull(metadataStringAsciiActual);
+    Assert.assertNotNull(metadataStringUtf8Actual);
 
     Assert.assertArrayEquals(
         (byte[]) metadataByte.toJavaArray(), (byte[]) metadataByteActual.toJavaArray());
@@ -507,6 +534,16 @@ public class ArrayTest {
         (byte[]) metadataString.toJavaArray(), (byte[]) metadataStringActual.toJavaArray());
     Assert.assertEquals(
         "русский", new String((byte[]) metadataString.toJavaArray(), StandardCharsets.UTF_8));
+    Assert.assertArrayEquals(
+        (byte[]) metadataStringAscii.toJavaArray(),
+        (byte[]) metadataStringAsciiActual.toJavaArray());
+    Assert.assertEquals(
+        "Russia",
+        new String((byte[]) metadataStringAscii.toJavaArray(), StandardCharsets.ISO_8859_1));
+    Assert.assertArrayEquals(
+        (byte[]) metadataStringUtf8.toJavaArray(), (byte[]) metadataStringUtf8Actual.toJavaArray());
+    Assert.assertEquals(
+        "русский", new String((byte[]) metadataStringUtf8.toJavaArray(), StandardCharsets.UTF_8));
 
     // exctracion of metadata without specifying the Datatype
     for (int i = 0; i < keysNum; i++) {

--- a/src/test/java/io/tiledb/java/api/ArrayTest.java
+++ b/src/test/java/io/tiledb/java/api/ArrayTest.java
@@ -533,7 +533,7 @@ public class ArrayTest {
     Assert.assertArrayEquals(
         (byte[]) metadataString.toJavaArray(), (byte[]) metadataStringActual.toJavaArray());
     Assert.assertEquals(
-        "русский", new String((byte[]) metadataString.toJavaArray(), StandardCharsets.UTF_8));
+        "???????", new String((byte[]) metadataString.toJavaArray(), StandardCharsets.ISO_8859_1));
     Assert.assertArrayEquals(
         (byte[]) metadataStringAscii.toJavaArray(),
         (byte[]) metadataStringAsciiActual.toJavaArray());


### PR DESCRIPTION
Follow on from #196 and support some more string encodings. Also when a particular encoding is chosen (ISO-8859-1 in particular), use it rather than always encoding in UTF-8. I am assuming this was the intent for the `TILEDB_STRING_ASCII` type but let me know whether pure US-ASCII was actually intended. This should make TileDB-Java compatible with all the string encodings that are currently possible via TileDB-Py.

/cc @kkoz, @erindiel