### PR TITLE
Add README files under JNI SWIG related directories [ch8456]

### DIFF
--- a/src/main/c/README.md
+++ b/src/main/c/README.md
@@ -1,0 +1,13 @@
+# JNI Generated Code
+
+This directory contains the C++ code that is used by the JNI native methods, under the `io.tiledb.java.libtiledb.tiledb` class.
+The code is separated into two directoriesn, namely custom and generated.
+
+## ./generated
+The `tiledb_wrap.cxx` file under this directory contains the auto-generated JNI C++ code, using SWIG.
+
+## ./custom
+The `tiledb_custom.cxx` file under this directory contains custom methods defined by the developer that are  not
+auto-generated. Any custom method that needs to be added should be put in this file. Also, the signature of the
+new custom method should be also put in the `tiledb.i` file under the `TileDB-Java/swig` dir. For implementation details,
+all `*_nio` methods (e.g. `tiledb_query_set_subarray_nio`) are good examples.

--- a/src/main/java/io/tiledb/java/api/README.md
+++ b/src/main/java/io/tiledb/java/api/README.md
@@ -1,0 +1,3 @@
+# Java API
+
+Contains all the implementations of the TileDB-Java API.

--- a/src/main/java/io/tiledb/libtiledb/README.md
+++ b/src/main/java/io/tiledb/libtiledb/README.md
@@ -1,0 +1,2 @@
+# libtiledb
+Contains all the aut-generated data types and methods by SWIG.

--- a/swig/README.md
+++ b/swig/README.md
@@ -1,0 +1,19 @@
+# SWIG
+
+This directory contains the basic SWIG files. 
+
+### customCode
+Contains custom method implementations.
+
+- NativeLibLoader.java: Helper methods for loading native libraries (e.g. `.so` files)
+- PointerUtils.java: Pointer conversion methods
+- Utils.java: Custom JNI methods
+
+The rest of the files are auto-generated.
+
+### tiledb.i
+The SWIG interface (`.i`) file. More info can be found at the official SWIG documentation: http://www.swig.org/tutorial.html
+
+### tiledb_java_extensions.h
+Contains some extensions of the `tiledb.h` (https://github.com/TileDB-Inc/TileDB/blob/dev/tiledb/sm/c_api/tiledb.h) library that we use in Java. Most of these extensions are implementations of
+`dump()` methods that print the dumb to the `stdout` (e.g. `tiledb_fragment_info_dump_stdout`).


### PR DESCRIPTION
EADME files for the TileDB-Java repository individual subdirectories