### PR TITLE
Add example Dockerfile for Windows

### DIFF
--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -1,0 +1,12 @@
+FROM winamd64/openjdk:18-ea-20-jdk-windowsservercore-1809
+
+SHELL ["cmd", "/S", "/C"] 
+
+ADD https://github.com/TileDB-Inc/TileDB-Java/releases/download/0.5.4/tiledb-java-0.5.4.jar tiledb-java-0.5.4.jar
+
+ADD VersionPrinter.java VersionPrinter.java
+
+RUN javac -cp tiledb-java-0.5.4.jar;. VersionPrinter.java
+
+ENTRYPOINT java -cp tiledb-java-0.5.4.jar;. VersionPrinter
+

--- a/docker/windows/README.md
+++ b/docker/windows/README.md
@@ -1,0 +1,9 @@
+# Example Windows Dockerfile
+
+This directory contains an example Dockerfile runnable under Docker for Windows. Usage:
+
+1) clone repository, or copy `Dockerfile` and `VersionPrinter.java`
+
+2) run `docker build -t tiledb-java-win .`
+
+3) run `docker run tiledb-java-win`

--- a/docker/windows/VersionPrinter.java
+++ b/docker/windows/VersionPrinter.java
@@ -1,0 +1,12 @@
+// javac -cp tiledb-java-0.5.4.tar VersionPrinter.java
+// java -cp tiledb-java-0.5.4.jar VersionPrinter
+
+import io.tiledb.java.api.Version;
+
+
+public class VersionPrinter {
+  public static void main(String[] args) throws Exception {
+    Version version = new Version();
+    System.out.println(version);
+  }
+}


### PR DESCRIPTION
Adds an example Docker for Windows Dockerfile, which links the TileDB jar and prints the embedded libtiledb version. [x-ref forum discussion](https://forum.tiledb.com/t/tiledb-not-working-in-docker-windows-container/382).

Example should print `TileDB v2.3.3`:

```
(base) PS C:\git\TileDB-Java\docker\windows> docker build -t tiledb-java-win .
Sending build context to Docker daemon  4.096kB
Step 1/6 : FROM winamd64/openjdk:18-ea-20-jdk-windowsservercore-1809
---> dd24948304ae
Step 2/6 : SHELL ["cmd", "/S", "/C"]                                                                                                                                                                            ---> Using cache
---> 106cd89aec0d
Step 3/6 : ADD https://github.com/TileDB-Inc/TileDB-Java/releases/download/0.5.4/tiledb-java-0.5.4.jar tiledb-java-0.5.4.jar                                                                                   Downloading [==================================================>]  12.65MB/12.65MB
---> Using cache
---> dac74fa7702d
Step 4/6 : ADD VersionPrinter.java VersionPrinter.java
---> Using cache
---> 7277340ddf78
---> Using cache                                                                                                                                                                                               ---> ef7362d9105a
Step 6/6 : ENTRYPOINT java -cp tiledb-java-0.5.4.jar;. VersionPrinter
---> Using cache
---> 39f7fba2aeea
Successfully built 39f7fba2aeea
Successfully tagged tiledb-java-win:latest

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
(base) PS C:\git\TileDB-Java\docker\windows> docker run tiledb-java-win
TileDB v2.3.3     
```