### PR TITLE
Enable tiledb_experimental SWIG generation

### DIFF
--- a/generate_tiledb_jni
+++ b/generate_tiledb_jni
@@ -60,6 +60,7 @@ fi
 
 # Test if we can find the installed tiledb header
 tiledb_header="${prefix_dir}/include/tiledb/tiledb.h"
+tiledb_experimental_header="${prefix_dir}/include/tiledb/tiledb_experimental.h"
 if [ ! -f ${tiledb_header} ]; then
   die "${tiledb_header} not found"
 fi
@@ -94,11 +95,11 @@ fi
 
 # define the necessary macro contants
 # (removed during preprocessor macro expansion)
-g++ -dM -E ${tiledb_header} | grep "#define TILEDB" > swig/tiledb_generated.h ||
+g++ -dM -E ${tiledb_header} ${tiledb_experimental_header} | grep "#define TILEDB" > swig/tiledb_generated.h ||
   die "could not write ./swig/tiledb_generated.h tmp file"
 
 # remove system headers
-awk '!/#\s*include/ || /tiledb_/ {print}' ${tiledb_header} |
+awk '!/#\s*include/ || /tiledb_/ {print}' ${tiledb_header} ${tiledb_experimental_header} |
 g++ -E -P -nostdinc++ -I "${tiledb_include}" -x c++ - >> swig/tiledb_generated.h ||
   die "error generating temp combined swig/tiledb_generated.h header for swig generation"
 

--- a/swig/tiledb.i
+++ b/swig/tiledb.i
@@ -38,6 +38,7 @@ import java.nio.ByteBuffer;
 #include <stdio.h>
 
 #include "tiledb/tiledb.h"
+#include "tiledb/tiledb_experimental.h"
 #include "tiledb_java_extensions.h"
 %}
 
@@ -137,6 +138,9 @@ import java.nio.ByteBuffer;
 %native (uint16ArrayGet) jintArray uint16ArrayGet(jlong array, jint pos, jint sz);
 %native (uint32ArrayGet) jlongArray uint32ArrayGet(jlong array, jint pos, jint sz);
 %native (uint64ArrayGet) jlongArray uint64ArrayGet(jlong array, jint pos, jint sz);
+
+// tiledb_experimental.h
+%pointer_functions(tiledb_array_schema_evolution_t*, tiledb_array_schema_evolution_tpp);
 
 %include "tiledb_generated.h"
 %include "tiledb_java_extensions.h"


### PR DESCRIPTION
Don't filter out the new header in generate_tiledb_jni