### PR TITLE
 Fix incomplete linux jars after build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,11 +127,12 @@ test {
 jar {
     into(new File('lib').toString()) {
         // Linux and macOS
-        from file("$buildDir/install/lib/libtiledb.dylib")
+        from file("$buildDir/install/lib/libtiledb.so")
         from file("$buildDir/install/lib64/libtiledb.so")
         from file("$buildDir/tiledb_jni/libtiledbjni.so")
 
         from file("$buildDir/install/lib/libtiledb.dylib")
+        from file("$buildDir/install/lib64/libtiledb.dylib")
         from file("$buildDir/tiledb_jni/libtiledbjni.dylib")
 
         // Windows


### PR DESCRIPTION
In my understanding the build will generate a ```TileDB-Java/build/install/lib``` OR ```TileDB-Java/build/install/lib64``` directory depending on the architecture. In the ```lib``` cases (e.g. the Alpine OS docker image) the produced jars in linux do not contain the ```libtiledb.so``` in the final jar. 

The ```test``` task does not use the jar but rather takes the .so files directly from the build directories (lib or lib64) and that's why no error was thrown in the CI.   
