### PR TITLE
Update SWIG generation for TileDB#3306 CAPIHandle changes

### DIFF
--- a/generate_tiledb_jni
+++ b/generate_tiledb_jni
@@ -95,15 +95,15 @@ if [[ ! -x `which swig` ]]; then
   die "swig wrapper generator not found in path"
 fi
 
-# define the necessary macro contants
+# define the necessary macro constants
 # (removed during preprocessor macro expansion)
 g++ -dM -I ${prefix_dir}/include -x c++-header -E ${tiledb_header} ${tiledb_experimental_header} | grep "#define TILEDB" > swig/tiledb_generated.h ||
   die "could not write ./swig/tiledb_generated.h tmp file"
 
-# remove system headers
-awk '!/#\s*include/ || /tiledb_/ {print}' ${tiledb_header} ${tiledb_experimental_header} |
-g++ -E -P -nostdinc++ -I "${tiledb_include}" -x c++ - >> swig/tiledb_generated.h ||
-  die "error generating temp combined swig/tiledb_generated.h header for swig generation"
+## remove system headers
+awk '!/#\s*include/ || /tiledb_/ || /tiledb\/api/ {print}' ${tiledb_header} ${tiledb_experimental_header} |
+   g++ -E -P -nostdinc++  -I "${prefix_dir}/include/tiledb" -I "${prefix_dir}/include/" -x c++ - >> swig/tiledb_generated.h ||
+   die "error generating temp combined swig/tiledb_generated.h header for swig generation"
 
 # if existing libtiledb generated source exists, delete it
 cleanup_java() {
@@ -112,7 +112,7 @@ cleanup_java() {
   fi
 }
 
-cleanup_java 
+cleanup_java
 
 cleanup_cxx() {
   if [[ -d ./src/main/c/generated ]]; then
@@ -120,16 +120,15 @@ cleanup_cxx() {
   fi
 }
 
-cleanup_cxx 
+cleanup_cxx
 
 swig -v -java -c++ -package io.tiledb.libtiledb \
+                -I${prefix_dir}/include -I${prefix_dir}/include/tiledb \
                 -outdir src/main/java/io/tiledb/libtiledb \
 		-o src/main/c/generated/tiledb_wrap.cxx swig/tiledb.i
 
 cleanup_header() {
-  if [[ -f ./swig/tiledb_generated.h ]]; then
-    rm ./swig/tiledb_generated.h || true
-  fi
+  echo "noop";
 }
 
 case "$?" in

--- a/generate_tiledb_jni
+++ b/generate_tiledb_jni
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xe
+
 cd "$(dirname "$0")"
 
 die() {
@@ -95,7 +97,7 @@ fi
 
 # define the necessary macro contants
 # (removed during preprocessor macro expansion)
-g++ -dM -E ${tiledb_header} ${tiledb_experimental_header} | grep "#define TILEDB" > swig/tiledb_generated.h ||
+g++ -dM -I ${prefix_dir}/include -x c++-header -E ${tiledb_header} ${tiledb_experimental_header} | grep "#define TILEDB" > swig/tiledb_generated.h ||
   die "could not write ./swig/tiledb_generated.h tmp file"
 
 # remove system headers
@@ -106,7 +108,7 @@ g++ -E -P -nostdinc++ -I "${tiledb_include}" -x c++ - >> swig/tiledb_generated.h
 # if existing libtiledb generated source exists, delete it
 cleanup_java() {
   if [[ -d ./src/main/java/io/tiledb/libtiledb ]]; then
-    rm -r ./src/main/java/io/tiledb/libtiledb/* 
+    rm -r ./src/main/java/io/tiledb/libtiledb/*  || true
   fi
 }
 
@@ -114,7 +116,7 @@ cleanup_java
 
 cleanup_cxx() {
   if [[ -d ./src/main/c/generated ]]; then
-    rm -r ./src/main/c/generated/* 
+    rm -r ./src/main/c/generated/* || true
   fi
 }
 
@@ -126,7 +128,7 @@ swig -v -java -c++ -package io.tiledb.libtiledb \
 
 cleanup_header() {
   if [[ -f ./swig/tiledb_generated.h ]]; then
-    rm ./swig/tiledb_generated.h
+    rm ./swig/tiledb_generated.h || true
   fi
 }
 

--- a/swig/tiledb.i
+++ b/swig/tiledb.i
@@ -32,6 +32,11 @@ import java.nio.ByteBuffer;
 
 #define __attribute__(x)
 
+// Any typedef struct for a handle derivative must be defined here
+typedef struct tiledb_ctx_t tiledb_ctx_t;
+typedef struct tiledb_filter_t tiledb_filter_t;
+typedef struct tiledb_config_t tiledb_config_t;
+
 %{
 #include <string>
 #include <vector>
@@ -150,7 +155,7 @@ import java.nio.ByteBuffer;
 %include "tiledb_java_extensions.h"
 
 %pragma(java) modulecode=%{
-  
+
   public static int sizeOfType(Object array) {
     Class arrayClass = array.getClass();
     if (arrayClass.equals(int32_tArray.class)) {


### PR DESCRIPTION
- add `-I ${prefix_dir}/include` so that internal includes can be found
- add `-x c++-header` to silence warning
    ```
    warning: treating 'c-header' input as 'c++-header' when in C++ mode, this behavior is deprecated
    ```
- add `|| true` to some rm calls so they don't fail if the output has
  previously been removed

- x-ref https://github.com/TileDB-Inc/TileDB/pull/3306