### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.12.1-SNAPSHOT'
+version '0.12.2-SNAPSHOT'
 
 repositories {
     jcenter()


### PR DESCRIPTION
Necessary after every release. This is because if someone wants to build from source, the correct version needs to be in the jar name.