### PR TITLE
fixing a bug when reading nullable attributes with nio buffers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.17.0-SNAPSHOT'
+version '0.17.2-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/src/main/c/custom/tiledb_custom.cxx
+++ b/src/main/c/custom/tiledb_custom.cxx
@@ -1207,7 +1207,7 @@ extern "C" {
     }
     arg4 = *(uint8_t **)&jarg4;
     arg5 = *(uint64_t **)&jarg5;
-    result = (int32_t)tiledb_query_set_validity_buffer(arg1,arg2,(char const *)arg3,arg4,arg5);
+    result = (int32_t)tiledb_query_set_validity_buffer(arg1,arg2,(char const *)arg3,(uint8_t *)buffer,arg5);
     jresult = (jint)result;
     if (arg3) jenv->ReleaseStringUTFChars(jarg3, (const char *)arg3);
     return jresult;

--- a/src/test/java/io/tiledb/java/api/QueryTest.java
+++ b/src/test/java/io/tiledb/java/api/QueryTest.java
@@ -1197,7 +1197,8 @@ public class QueryTest {
       }
     }
 
-    public void denseArrayNIOReadTest() throws Exception { // TODO
+    @Test
+    public void denseArrayNIOReadTest() throws Exception {
       denseArrayCreateNullableAttrs(true);
       denseArrayWrite();
 
@@ -1363,7 +1364,8 @@ public class QueryTest {
       }
     }
 
-    public void sparseArrayNIOReadTest() throws Exception { // TODO
+    @Test
+    public void sparseArrayNIOReadTest() throws Exception {
       sparseArrayCreateNullableAttrs(true);
       sparseArrayWrite();
 


### PR DESCRIPTION
This bug is a leftover from the major overhaul of the API in the 2.15 update.