### PR TITLE
update gradle-build-action to 2.4.2

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -18,17 +18,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: checkFormat
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: checkFormat
 
       - name: assemble
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: assemble
 
       - name: test
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: test
     env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,11 +39,11 @@ jobs:
           (Get-Content gradle.properties) | ForEach-Object { $_ -replace 'TILEDB_GIT_TAG=.*', 'TILEDB_GIT_TAG=dev' } | Set-Content gradle.properties
           (Get-Content gradle.properties) | ForEach-Object { $_ -replace 'DOWNLOAD_TILEDB_PREBUILT=.*', 'DOWNLOAD_TILEDB_PREBUILT=OFF' } | Set-Content gradle.properties
       - name: assemble
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: assemble
 
       - name: test
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: test


### PR DESCRIPTION
Fixing a security vulnerability by updating to gradle-build-action v2.4.2