### PR TITLE
ArraySchema.toString() checks if domain is set

### DIFF
--- a/src/main/java/io/tiledb/java/api/ArraySchema.java
+++ b/src/main/java/io/tiledb/java/api/ArraySchema.java
@@ -76,6 +76,7 @@ public class ArraySchema implements AutoCloseable {
 
   private Context ctx;
   private ArrayType arrayType;
+  private boolean domainIsSet = false;
   private HashMap<String, Attribute> attributes;
 
   private SWIGTYPE_p_tiledb_array_schema_t schemap;
@@ -331,6 +332,7 @@ public class ArraySchema implements AutoCloseable {
   public void setDomain(Domain domain) throws TileDBError {
     ctx.handleError(
         tiledb.tiledb_array_schema_set_domain(ctx.getCtxp(), getSchemap(), domain.getDomainp()));
+    domainIsSet = true;
   }
 
   /**
@@ -771,7 +773,7 @@ public class ArraySchema implements AutoCloseable {
       StringBuilder s = new StringBuilder("ArraySchema<");
       s.append(getArrayType().name());
       s.append(" ");
-      s.append(getDomain());
+      if (domainIsSet) s.append(getDomain());
       for (Map.Entry e : getAttributes().entrySet()) {
         s.append(" ");
         s.append(e.getValue());

--- a/src/test/java/io/tiledb/java/api/ArraySchemaTest.java
+++ b/src/test/java/io/tiledb/java/api/ArraySchemaTest.java
@@ -41,6 +41,7 @@ public class ArraySchemaTest {
     ArraySchema schema = new ArraySchema(ctx, arrayType);
     schema.setTileOrder(Layout.TILEDB_ROW_MAJOR);
     schema.setCellOrder(cellOrder);
+    Assert.assertNotNull(schema.toString());
     schema.setDomain(domain);
     schema.addAttribute(a1);
     return schema;


### PR DESCRIPTION
Full description can be found in the shortcut story. This was causing the debugger to crash if a breakpoint was set between the ArraySchema creation and setting its domain. 