### PR TITLE
SubArray's ```close()``` method no longer closes the Array

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.17.8-SNAPSHOT'
+version '0.17.9-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/src/main/java/io/tiledb/java/api/SubArray.java
+++ b/src/main/java/io/tiledb/java/api/SubArray.java
@@ -798,14 +798,11 @@ public class SubArray implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     if (subArrayp != null && subArraypp != null) {
       tiledb.tiledb_subarray_free(subArraypp);
       subArrayp = null;
       subArraypp = null;
-      if (array != null) {
-        array.close();
-      }
     }
   }
 }


### PR DESCRIPTION
#301
Correcting the behavior of the ```close()``` method in the subArray class. Will issue a patch release to facilitate @chris-allan's work.