### PR TITLE
exit submit method quickly in case of ```TILEDB_WRITE```

### DIFF
--- a/src/main/java/io/tiledb/java/api/Query.java
+++ b/src/main/java/io/tiledb/java/api/Query.java
@@ -129,6 +129,8 @@ public class Query implements AutoCloseable {
   public QueryStatus submit() throws TileDBError {
     ctx.handleError(tiledb.tiledb_query_submit(ctx.getCtxp(), queryp));
 
+    if (this.type == QueryType.TILEDB_WRITE) return getQueryStatus();
+
     // Set the actual number of bytes received to each ByteBuffer
     for (String attribute : byteBuffers_.keySet()) {
       boolean isVar;


### PR DESCRIPTION
There is no need to run the entire submit method and populate the buffers when writing. This was the case before this proposed change. This will save memory when writing to arrays