### PR TITLE
fix jars with no .so/.dll/.dylib file when using a custom-built libtiledb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,18 +126,33 @@ test {
 
 jar {
     into(new File('lib').toString()) {
-        // Linux and macOS
-        from file("$buildDir/install/lib/libtiledb.so")
-        from file("$buildDir/install/lib64/libtiledb.so")
+        String tiledbHome = System.getenv("TILEDB_HOME")
+
+        if (tiledbHome != null) {
+            // linux
+            from file("$tiledbHome/lib/libtiledb.so")
+            from file("$tiledbHome/lib64/libtiledb.so")
+            // macOS
+            from file("$tiledbHome/lib/libtiledb.dylib")
+            from file("$tiledbHome/lib64/libtiledb.dylib")
+            // windows
+            from file("$tiledbHome/bin/tbb.dll")
+            from file("$tiledbHome/bin/tiledb.dll")
+
+        } else {
+            // linux
+            from file("$buildDir/install/lib/libtiledb.so")
+            from file("$buildDir/install/lib64/libtiledb.so")
+            // macOS
+            from file("$buildDir/install/lib/libtiledb.dylib")
+            from file("$buildDir/install/lib64/libtiledb.dylib")
+            // Windows
+            from file("$buildDir/install/bin/tbb.dll")
+            from file("$buildDir/install/bin/tiledb.dll")
+        }
+        // jni
         from file("$buildDir/tiledb_jni/libtiledbjni.so")
-
-        from file("$buildDir/install/lib/libtiledb.dylib")
-        from file("$buildDir/install/lib64/libtiledb.dylib")
         from file("$buildDir/tiledb_jni/libtiledbjni.dylib")
-
-        // Windows
-        from file("$buildDir/install/bin/tbb.dll")
-        from file("$buildDir/install/bin/tiledb.dll")
         from file("$buildDir/tiledb_jni/Release/tiledbjni.dll")
     }
 


### PR DESCRIPTION
This PR solves an issue in cases where a user wants to assemble the TileDB-Java API by using a libtiledb which they have built from source and have exported to the TILEDB_HOME env variable. Previously the ./gradlew assemble command would not locate the .so/.dll/.dylib lib files from the external TileDB build, thus resulting in creating TileDB-Java jars without libtiledb. 

This PR is tested manually in: 

- [x] macOS
- [x] linux
- [ ] Windows (Pending)