### PR TITLE
add native support for Apple Silicon macs

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -40,11 +40,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-11 ]
+        os: [ ubuntu-latest, macos-11, macos-13-xlarge ]
 
     steps:
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          check-latest: true
 
       - run: |
           unset SYSTEM
@@ -63,21 +70,6 @@ jobs:
           ./gradlew test
         shell: bash
         name: test
-
-      - run: |
-          set -e pipefail
-          # Display log files if the build failed
-          echo "Dumping log files for failed build"
-          echo "----------------------------------"
-          for f in $(find $BUILD_REPOSITORY_LOCALPATH -name *.dumpstream);
-            do echo "------"
-               echo $f
-               echo "======"
-               cat $f
-            done;
-        shell: bash
-        name: error_print
-        if: ${{ failure() }}
 
     env:
       ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: OFF

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -41,7 +41,6 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-11, macos-13-xlarge ]
-
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -95,11 +94,11 @@ jobs:
           p=$(readlink -f *.jar)
           cd ../../src/main/java/examples/io/tiledb/java/api
           javac -cp $p *.java
-          for x in $(ls -1 *.java | sed 's/.java//'); 
-          do 
+          for x in $(ls -1 *.java | sed 's/.java//');
+          do
           echo $x;
-          class_name=examples.io.tiledb.java.api.$x; 
-          java -cp $p $class_name; 
+          class_name=examples.io.tiledb.java.api.$x;
+          java -cp $p $class_name;
           done
 
     env:
@@ -160,8 +159,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-11, ubuntu-latest ]
+        os: [ macos-11, ubuntu-latest, macos-13-xlarge]
     steps:
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          check-latest: true
+
       - name: checkout
         uses: actions/checkout@v3
 
@@ -175,30 +182,30 @@ jobs:
             docker run -e "CFLAGS=$CFLAGS" -e "CPPFLAGS=$CPPFLAGS" -v $(pwd):/TileDB-Java -t lib_builder_2010 /TileDB-Java/ci/build.sh
             cp ./build/tiledb_jni/*.so ./build/install/lib/*.so ./build/install/lib64/*.so binaries_$RUNNER_OS/
           fi
-
-          if [[ ( "$RUNNER_OS" == "macOS" ) ]]; then
-            ./gradlew -PTILEDB_AZURE=ON assemble
-            cp ./build/tiledb_jni/*.dylib ./build/install/lib/*.dylib binaries_$RUNNER_OS/
+          
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            if [[ "$(uname -m)" == "arm64" ]]; then
+              mkdir -p binaries_apple_silicon/arm
+              ./gradlew -PTILEDB_AZURE=ON assemble
+              cp ./build/tiledb_jni/arm/*.dylib ./build/install/arm/lib/*.dylib binaries_apple_silicon/arm
+            else
+              ./gradlew -PTILEDB_AZURE=ON assemble
+              cp ./build/tiledb_jni/*.dylib ./build/install/lib/*.dylib binaries_$RUNNER_OS/
+            fi
           fi
 
         name: 'Build and Upload (Ubuntu and OSX)'
 
       - run: |
-          set -e pipefail
-          # Display log files if the build failed
-          echo "Dumping log files for failed build"
-          echo "----------------------------------"
-          for f in $(find $BUILD_REPOSITORY_LOCALPATH -name *.log);
-            do echo "------"
-               echo $f
-               echo "======"
-               cat $f
-            done;
-        if: ${{ failure() }}
-        name: "Print log files (failed build only)"
-
-      - run: |
-          tar cvf tiledb-$RUNNER_OS.gz.tar binaries_$RUNNER_OS/
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            if [[ "$(uname -m)" == "arm64" ]]; then
+              tar cvf tiledb-apple-silicon.gz.tar binaries_apple_silicon/
+            else
+              tar cvf tiledb-$RUNNER_OS.gz.tar binaries_$RUNNER_OS/
+            fi
+          else 
+            tar cvf tiledb-$RUNNER_OS.gz.tar binaries_$RUNNER_OS/
+          fi
         name: Archive_files
 
       - uses: actions/upload-artifact@v2
@@ -211,15 +218,21 @@ jobs:
         with:
           name: Upload-Artifact-Mac
           path: '*.gz.tar'
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && (runner.arch == 'X86' || runner.arch == 'X64')
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Upload-Artifact-Mac-Arm
+          path: '*.gz.tar'
+        if: runner.os == 'macOS' && (runner.arch == 'ARM' || runner.arch == 'arm64')
     env:
       ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
-  Release:
+  Setup-Release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [Create_Artifacts_Ubuntu_MacOS, Create_Artifacts_Windows]
-    name: Create-Release
+    name: Setup-Release
     runs-on: ubuntu-latest
     steps:
 
@@ -242,8 +255,10 @@ jobs:
           mv Upload-*/* .
 
           mkdir -p ./build/install/lib
+          mkdir -p ./build/install/arm/lib
           mkdir ./build/install/lib64
           mkdir ./build/tiledb_jni/
+          mkdir ./build/tiledb_jni/arm
           mkdir ./build/tiledb_jni/Release
           mkdir ./build/install/bin
 
@@ -258,7 +273,9 @@ jobs:
           # OSX
           mv libtiledb.dylib ./build/install/lib
           mv libtiledbjni.dylib ./build/tiledb_jni
-
+          mv arm/libtiledb.dylib ./build/install/arm/lib
+          mv arm/libtiledbjni.dylib ./build/tiledb_jni/arm
+          
           # Linux
           cp libtiledb.so ./build/install/lib
           mv libtiledb.so ./build/install/lib64
@@ -273,6 +290,87 @@ jobs:
 
           mkdir jars
           cp ./build/libs/*.jar jars
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: jars
+          path: ./jars
+
+    env:
+      ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
+      ORG_GRADLE_PROJECT_TILEDB_S3: ON
+
+
+  Test-Release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [ Setup-Release ]
+    name: Test-Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-11, ubuntu-latest, macos-13-xlarge, windows-2019 ]
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set-up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          check-latest: true
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: jars
+
+      - shell: bash
+        name: Run examples with release jar
+        run: |
+          
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+              brew install coreutils;
+          fi
+          
+          rm *javadoc* *sources*
+
+          p=$(realpath *.jar)
+          
+          # Change directory to the specified path
+          cd src/main/java/examples/io/tiledb/java/api
+          
+          # Compile all Java files in the current directory using the classpath obtained earlier
+          javac -cp "$p" *.java
+          
+          # Loop through all compiled Java files and run them
+          for x in $(ls -1 *.java | sed 's/.java//'); do
+            echo $x;
+            class_name=examples.io.tiledb.java.api.$x;
+            java -cp "$p" $class_name;
+          done
+    env:
+      ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
+      ORG_GRADLE_PROJECT_TILEDB_S3: ON
+
+  Release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [ Test-Release ]
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: jars
+
+      - name: Package jars
+        run: |
+          mkdir jars;
+          mv *.jar ./jars;
 
       - name: Create Release
         id: create_release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,15 @@ if (TILEDB_JNI_SUPERBUILD)
   project(TileDB-JNI-Superbuild)
 
   # Path to install everything to, for embedding in the jar.
-  set(RESOURCE_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/install")
+  if (APPLE) # macOS
+    if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
+        set(RESOURCE_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/install")
+    else()
+            set(RESOURCE_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/install/arm")
+    endif()
+  else()
+        set(RESOURCE_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/install")
+  endif()
 
   message(STATUS "Starting TileDB-JNI superbuild.")
   include("cmake/TileDB-JNI-Superbuild.cmake")

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,19 @@ dependencies {
 }
 
 task cmakeTask(type: Exec) {
-    File jniLibs = new File(buildDir.path + "/tiledb_jni")
-    File tiledbLibs = new File(buildDir.path + "/install/lib")
+    def osName = System.getProperty('os.name').toLowerCase()
+    def arch = System.getProperty('os.arch').toLowerCase()
+
+    File jniLibs;
+    File tiledbLibs;
+
+    if (osName.contains("mac") && arch.equals("aarch64")) {
+        jniLibs = new File(buildDir.path + "/tiledb_jni/arm")
+        tiledbLibs = new File(buildDir.path + "/install/arm/lib")
+    }else{
+        jniLibs = new File(buildDir.path + "/tiledb_jni")
+        tiledbLibs = new File(buildDir.path + "/install/lib")
+    }
 
     onlyIf { !buildDir.exists() || !jniLibs.exists() || !tiledbLibs.exists() }
     doFirst {
@@ -83,8 +94,19 @@ task cmakeTask(type: Exec) {
 }
 
 task cmakeBuildTask(type: Exec) {
-    File jniLibs = new File(buildDir.path + "/tiledb_jni")
-    File tiledbLibs = new File(buildDir.path + "/install/lib")
+    def osName = System.getProperty('os.name').toLowerCase()
+    def arch = System.getProperty('os.arch').toLowerCase()
+
+    File jniLibs;
+    File tiledbLibs;
+
+    if (osName.contains("mac") && arch.equals("aarch64")) {
+        jniLibs = new File(buildDir.path + "/tiledb_jni/arm")
+        tiledbLibs = new File(buildDir.path + "/install/arm/lib")
+    }else{
+        jniLibs = new File(buildDir.path + "/tiledb_jni")
+        tiledbLibs = new File(buildDir.path + "/install/lib")
+    }
 
     onlyIf { !buildDir.exists() || !jniLibs.exists() || !tiledbLibs.exists() }
     doFirst {
@@ -116,7 +138,7 @@ test {
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         systemProperty "java.library.path", "$buildDir\\install\\bin;$buildDir\\tiledb_jni\\Release"
     } else {
-        systemProperty "java.library.path", "$buildDir/install/lib:$buildDir/install/lib64:$buildDir/tiledb_jni"
+        systemProperty "java.library.path", "$buildDir/install/lib:$buildDir/install/lib64:$buildDir/tiledb_jni:$buildDir/install/arm/lib:$buildDir/tiledb_jni/arm"
     }
 
     testLogging {
@@ -125,12 +147,19 @@ test {
 }
 
 jar {
+    // macOS arm
+    into(new File('arm/lib').toString()) {
+        from file("$buildDir/install/arm/lib/libtiledb.dylib")
+        from file("$buildDir/tiledb_jni/arm/libtiledbjni.dylib")
+    }
+
     into(new File('lib').toString()) {
-        // Linux and macOS
+        // Linux
         from file("$buildDir/install/lib/libtiledb.so")
         from file("$buildDir/install/lib64/libtiledb.so")
         from file("$buildDir/tiledb_jni/libtiledbjni.so")
 
+        // macOS intel
         from file("$buildDir/install/lib/libtiledb.dylib")
         from file("$buildDir/install/lib64/libtiledb.dylib")
         from file("$buildDir/tiledb_jni/libtiledbjni.dylib")
@@ -140,6 +169,7 @@ jar {
         from file("$buildDir/install/bin/tiledb.dll")
         from file("$buildDir/tiledb_jni/Release/tiledbjni.dll")
     }
+
 
     manifest {
         attributes("Implementation-Title": "Gradle",

--- a/cmake/Modules/FindTileDB_EP.cmake
+++ b/cmake/Modules/FindTileDB_EP.cmake
@@ -48,14 +48,21 @@ if (NOT TILEDB_FOUND)
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-windows-x86_64-2.17.1-7c8c73b.zip")
-          SET(DOWNLOAD_SHA1 "c3757a9205299a4184bd4de7621ff9f5118f14ca")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-windows-x86_64-2.16.3-194b5ae.zip")
+          SET(DOWNLOAD_SHA1 "8e986b6143ef9509201c7f2b3c0a7a53ff41095a")
         elseif(APPLE) # macOS
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-macos-x86_64-2.17.1-7c8c73b.tar.gz")
-          SET(DOWNLOAD_SHA1 "998c099297c0441af40729634642bd358c962da6")
+            if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+                message(STATUS "Building for intel mac")
+                SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-macos-x86_64-2.16.3-194b5ae.tar.gz")
+                SET(DOWNLOAD_SHA1 "b4d35306771d1c30b49bf2a98651e8e24c91037e")
+            else()
+                message(STATUS "Building for apple silicon mac")
+                SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-macos-arm64-2.16.3-194b5ae.tar.gz")
+                SET(DOWNLOAD_SHA1 "1f3f0e7660ed54b8988bdfcc4876021bf57d58da")
+            endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-linux-x86_64-2.17.1-7c8c73b.tar.gz")
-          SET(DOWNLOAD_SHA1 "c01bf6898ef5bd108d49b378aa30aadfc3131b75")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-linux-x86_64-2.16.3-194b5ae.tar.gz")
+          SET(DOWNLOAD_SHA1 "6ccafbee52137478d0b8146e71a11323755c9ed5")
         endif()
 
         ExternalProject_Add(ep_tiledb

--- a/cmake/Modules/FindTileDB_EP.cmake
+++ b/cmake/Modules/FindTileDB_EP.cmake
@@ -48,21 +48,24 @@ if (NOT TILEDB_FOUND)
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-windows-x86_64-2.16.3-194b5ae.zip")
-          SET(DOWNLOAD_SHA1 "8e986b6143ef9509201c7f2b3c0a7a53ff41095a")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-windows-x86_64-2.17.1-7c8c73b.zip")
+          SET(DOWNLOAD_SHA1 "c3757a9205299a4184bd4de7621ff9f5118f14ca")
         elseif(APPLE) # macOS
-            if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-                message(STATUS "Building for intel mac")
-                SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-macos-x86_64-2.16.3-194b5ae.tar.gz")
-                SET(DOWNLOAD_SHA1 "b4d35306771d1c30b49bf2a98651e8e24c91037e")
-            else()
-                message(STATUS "Building for apple silicon mac")
-                SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-macos-arm64-2.16.3-194b5ae.tar.gz")
-                SET(DOWNLOAD_SHA1 "1f3f0e7660ed54b8988bdfcc4876021bf57d58da")
-            endif()
+
+          if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
+            message(STATUS "Building for intel mac")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-macos-x86_64-2.17.1-7c8c73b.tar.gz")
+            SET(DOWNLOAD_SHA1 "998c099297c0441af40729634642bd358c962da6")
+
+          elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+            message(STATUS "Building for apple silicon mac")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-macos-arm64-2.17.1-7c8c73b.tar.gz")
+            SET(DOWNLOAD_SHA1 "23b2c8a18b7ad4198516f7975b51ce47e7dee56d")
+          endif()
+
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.16.3/tiledb-linux-x86_64-2.16.3-194b5ae.tar.gz")
-          SET(DOWNLOAD_SHA1 "6ccafbee52137478d0b8146e71a11323755c9ed5")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.17.1/tiledb-linux-x86_64-2.17.1-7c8c73b.tar.gz")
+          SET(DOWNLOAD_SHA1 "c01bf6898ef5bd108d49b378aa30aadfc3131b75")
         endif()
 
         ExternalProject_Add(ep_tiledb

--- a/cmake/TileDB-JNI-Superbuild.cmake
+++ b/cmake/TileDB-JNI-Superbuild.cmake
@@ -60,12 +60,38 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindTileDB_EP.cmake)
 # Set up the regular build (i.e. non-superbuild).
 ############################################################
 
-ExternalProject_Add(tiledb_jni
-  SOURCE_DIR ${PROJECT_SOURCE_DIR}
-  CMAKE_ARGS
-    -DTILEDB_JNI_SUPERBUILD=OFF
-    ${INHERITED_CMAKE_ARGS}
-  INSTALL_COMMAND ""
-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tiledb_jni
-  DEPENDS ${TILEDB_JNI_EXTERNAL_PROJECTS}
-)
+
+if (APPLE) # macOS
+    if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
+        ExternalProject_Add(tiledb_jni
+            SOURCE_DIR ${PROJECT_SOURCE_DIR}
+            CMAKE_ARGS
+                -DTILEDB_JNI_SUPERBUILD=OFF
+                ${INHERITED_CMAKE_ARGS}
+            INSTALL_COMMAND ""
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tiledb_jni/
+            DEPENDS ${TILEDB_JNI_EXTERNAL_PROJECTS}
+        )
+    else()
+        ExternalProject_Add(tiledb_jni
+            SOURCE_DIR ${PROJECT_SOURCE_DIR}
+            CMAKE_ARGS
+                -DTILEDB_JNI_SUPERBUILD=OFF
+                ${INHERITED_CMAKE_ARGS}
+            INSTALL_COMMAND ""
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tiledb_jni/arm
+            DEPENDS ${TILEDB_JNI_EXTERNAL_PROJECTS}
+        )
+    endif()
+else()
+    ExternalProject_Add(tiledb_jni
+        SOURCE_DIR ${PROJECT_SOURCE_DIR}
+        CMAKE_ARGS
+            -DTILEDB_JNI_SUPERBUILD=OFF
+            ${INHERITED_CMAKE_ARGS}
+        INSTALL_COMMAND ""
+        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tiledb_jni/
+        DEPENDS ${TILEDB_JNI_EXTERNAL_PROJECTS}
+    )
+endif()
+

--- a/src/main/c/custom/tiledb_custom.cxx
+++ b/src/main/c/custom/tiledb_custom.cxx
@@ -706,7 +706,7 @@ extern "C" {
 
     (void)jenv;
     (void)jcls;
-    if (!SWIG_JavaArrayInLonglong(jenv, &jarr1, (long long **)&arg1, jarg1)) return 0;
+    if (!SWIG_JavaArrayInLonglong(jenv, &jarr1, (jlong**)&arg1, jarg1)) return 0;
     SWIG_JavaArrayArgoutLonglong(jenv, jarr1, arg1, jarg1);
     *(void **)&jresult = (void *)arg1;
     return jresult;

--- a/src/main/java/io/tiledb/libtiledb/NativeLibLoader.java
+++ b/src/main/java/io/tiledb/libtiledb/NativeLibLoader.java
@@ -322,6 +322,12 @@ public class NativeLibLoader {
   private static Path findNativeLibrary(String libraryName, boolean mapLibraryName) {
     String mappedLibraryName = mapLibraryName ? System.mapLibraryName(libraryName) : libraryName;
     String libDir = LIB_RESOURCE_DIR;
+
+    if (System.getProperty("os.name").contains("mac")
+        && System.getProperty("os.arch").equals("aarch64")) {
+      libDir = "arm" + libDir;
+    }
+
     String libPath = libDir + "/" + mappedLibraryName;
 
     boolean hasNativeLib = hasResource(libPath);

--- a/swig/customCode/NativeLibLoader.java
+++ b/swig/customCode/NativeLibLoader.java
@@ -322,6 +322,12 @@ public class NativeLibLoader {
   private static Path findNativeLibrary(String libraryName, boolean mapLibraryName) {
     String mappedLibraryName = mapLibraryName ? System.mapLibraryName(libraryName) : libraryName;
     String libDir = LIB_RESOURCE_DIR;
+
+    if (System.getProperty("os.name").contains("mac")
+        && System.getProperty("os.arch").equals("aarch64")) {
+      libDir = "arm" + libDir;
+    }
+
     String libPath = libDir + "/" + mappedLibraryName;
 
     boolean hasNativeLib = hasResource(libPath);


### PR DESCRIPTION
This PR adds native support for Apple Silicon macs using the TileDB-Java API. It also adds the ARM native libs in the release jar.

I have modified the CI to test against Apple Silicon. I have also added an additional step just before the "release" to test the functionality of the fatJar on all platforms.

A complete run can be found here: https://github.com/TileDB-Inc/TileDB-Java/actions/runs/6495589089. This run created a draft release. You can inspect the final jar here: https://github.com/TileDB-Inc/TileDB-Java/releases/tag/untagged-8e30ff0d9545eb7048bb

[sc-11462]