### PR TITLE
fix memory leaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.1-SNAPSHOT'
+version '0.19.2-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/src/main/java/io/tiledb/java/api/ArraySchemaEvolution.java
+++ b/src/main/java/io/tiledb/java/api/ArraySchemaEvolution.java
@@ -41,6 +41,7 @@ public class ArraySchemaEvolution implements AutoCloseable {
   public void close() {
     if (evolutionp != null && evolutionpp != null) {
       tiledb.tiledb_array_schema_evolution_free(evolutionpp);
+      tiledb.delete_tiledb_array_schema_evolution_tpp(evolutionpp);
       evolutionpp = null;
       evolutionp = null;
     }

--- a/src/main/java/io/tiledb/java/api/BitWidthReductionFilter.java
+++ b/src/main/java/io/tiledb/java/api/BitWidthReductionFilter.java
@@ -13,23 +13,22 @@ public class BitWidthReductionFilter extends Filter {
 
   public BitWidthReductionFilter(Context ctx, int window) throws TileDBError {
     super(ctx, tiledb_filter_type_t.TILEDB_FILTER_BIT_WIDTH_REDUCTION);
-    try (NativeArray windowArray =
+    NativeArray windowArray =
         new NativeArray(
             ctx,
             new int[] {
               window,
             },
-            Integer.class)) {
-      ctx.handleError(
-          tiledb.tiledb_filter_set_option(
-              ctx.getCtxp(),
-              getFilterp(),
-              tiledb_filter_option_t.TILEDB_BIT_WIDTH_MAX_WINDOW,
-              windowArray.toVoidPointer()));
-    } catch (TileDBError err) {
-      super.close();
-      throw err;
-    }
+            Integer.class);
+
+    ctx.handleError(
+        tiledb.tiledb_filter_set_option(
+            ctx.getCtxp(),
+            getFilterp(),
+            tiledb_filter_option_t.TILEDB_BIT_WIDTH_MAX_WINDOW,
+            windowArray.toVoidPointer()));
+
+    windowArray.close();
   }
 
   protected BitWidthReductionFilter(Context ctx, SWIGTYPE_p_p_tiledb_filter_t filterpp) {
@@ -39,15 +38,15 @@ public class BitWidthReductionFilter extends Filter {
   public int getWindow() throws TileDBError {
     Context ctx = getCtx();
     int window;
-    try (NativeArray windowArray = new NativeArray(ctx, 1, Integer.class)) {
-      ctx.handleError(
-          tiledb.tiledb_filter_get_option(
-              ctx.getCtxp(),
-              getFilterp(),
-              tiledb_filter_option_t.TILEDB_BIT_WIDTH_MAX_WINDOW,
-              windowArray.toVoidPointer()));
-      window = (int) windowArray.getItem(0);
-    }
+    NativeArray windowArray = new NativeArray(ctx, 1, Integer.class);
+    ctx.handleError(
+        tiledb.tiledb_filter_get_option(
+            ctx.getCtxp(),
+            getFilterp(),
+            tiledb_filter_option_t.TILEDB_BIT_WIDTH_MAX_WINDOW,
+            windowArray.toVoidPointer()));
+    window = (int) windowArray.getItem(0);
+    windowArray.close();
     return window;
   }
 }

--- a/src/main/java/io/tiledb/java/api/CompressionFilter.java
+++ b/src/main/java/io/tiledb/java/api/CompressionFilter.java
@@ -10,23 +10,22 @@ public class CompressionFilter extends Filter {
   protected CompressionFilter(Context ctx, tiledb_filter_type_t filter_type, int level)
       throws TileDBError {
     super(ctx, filter_type);
-    try (NativeArray levelArray =
+    NativeArray levelArray =
         new NativeArray(
             ctx,
             new int[] {
               level,
             },
-            Integer.class)) {
-      ctx.handleError(
-          tiledb.tiledb_filter_set_option(
-              ctx.getCtxp(),
-              getFilterp(),
-              tiledb_filter_option_t.TILEDB_COMPRESSION_LEVEL,
-              levelArray.toVoidPointer()));
-    } catch (TileDBError err) {
-      super.close();
-      throw err;
-    }
+            Integer.class);
+
+    ctx.handleError(
+        tiledb.tiledb_filter_set_option(
+            ctx.getCtxp(),
+            getFilterp(),
+            tiledb_filter_option_t.TILEDB_COMPRESSION_LEVEL,
+            levelArray.toVoidPointer()));
+
+    levelArray.close();
   }
 
   protected CompressionFilter(Context ctx, SWIGTYPE_p_p_tiledb_filter_t filterpp) {
@@ -40,15 +39,17 @@ public class CompressionFilter extends Filter {
   public int getLevel() throws TileDBError {
     Context ctx = getCtx();
     int level;
-    try (NativeArray levelArray = new NativeArray(ctx, 1, Integer.class)) {
-      ctx.handleError(
-          tiledb.tiledb_filter_get_option(
-              ctx.getCtxp(),
-              getFilterp(),
-              tiledb_filter_option_t.TILEDB_COMPRESSION_LEVEL,
-              levelArray.toVoidPointer()));
-      level = (int) levelArray.getItem(0);
-    }
+    NativeArray levelArray = new NativeArray(ctx, 1, Integer.class);
+
+    ctx.handleError(
+        tiledb.tiledb_filter_get_option(
+            ctx.getCtxp(),
+            getFilterp(),
+            tiledb_filter_option_t.TILEDB_COMPRESSION_LEVEL,
+            levelArray.toVoidPointer()));
+    level = (int) levelArray.getItem(0);
+    levelArray.close();
+
     return level;
   }
 }

--- a/src/main/java/io/tiledb/java/api/Config.java
+++ b/src/main/java/io/tiledb/java/api/Config.java
@@ -75,6 +75,7 @@ public class Config implements AutoCloseable {
       tiledb.delete_tiledb_error_tpp(_errorpp);
       throw err;
     }
+
     tiledb.delete_tiledb_error_tpp(_errorpp);
     this.configpp = _configpp;
     this.configp = tiledb.tiledb_config_tpp_value(_configpp);
@@ -357,6 +358,7 @@ public class Config implements AutoCloseable {
   public void close() {
     if (configp != null) {
       tiledb.tiledb_config_free(configpp);
+      tiledb.delete_tiledb_config_tpp(configpp);
       configp = null;
       configpp = null;
     }

--- a/src/main/java/io/tiledb/java/api/ConsolidationPlan.java
+++ b/src/main/java/io/tiledb/java/api/ConsolidationPlan.java
@@ -48,6 +48,32 @@ public class ConsolidationPlan implements AutoCloseable {
   }
 
   /**
+   * Constructor
+   *
+   * @param fragmentSize The desired fragment size
+   * @param ctx TileDB context
+   * @param array The array to create the plan for
+   * @throws TileDBError
+   */
+  public ConsolidationPlan(Context ctx, BigInteger fragmentSize, Array array) throws TileDBError {
+    this.fragmentSize = fragmentSize;
+    this.ctx = ctx;
+    this.arrayURI = array.getUri();
+    SWIGTYPE_p_p_tiledb_consolidation_plan_t _consp = tiledb.new_tiledb_consolidation_plan_tpp();
+    try {
+      ctx.handleError(
+          tiledb.tiledb_consolidation_plan_create_with_mbr(
+              ctx.getCtxp(), array.getArrayp(), fragmentSize, _consp));
+    } catch (TileDBError e) {
+      tiledb.delete_tiledb_consolidation_plan_tpp(_consp);
+      throw e;
+    }
+
+    this.consp = tiledb.tiledb_consolidation_plan_tpp_value(_consp);
+    this.conspp = _consp;
+  }
+
+  /**
    * Get the number of fragments for a specific node of a consolidation plan object
    *
    * @param nodeIndex The node index
@@ -132,6 +158,7 @@ public class ConsolidationPlan implements AutoCloseable {
   public void close() throws Exception {
     if (consp != null) {
       tiledb.tiledb_consolidation_plan_free(conspp);
+      tiledb.delete_tiledb_consolidation_plan_tpp(conspp);
       consp = null;
       conspp = null;
     }

--- a/src/main/java/io/tiledb/java/api/Context.java
+++ b/src/main/java/io/tiledb/java/api/Context.java
@@ -258,9 +258,11 @@ public class Context implements AutoCloseable {
   /**
    * Close the context and delete all native objects. Should be called always to cleanup the context
    */
-  public void close() {
+  public void close() throws TileDBError {
+    this.getConfig().close();
     if (ctxp != null) {
       tiledb.tiledb_ctx_free(ctxpp);
+      tiledb.delete_tiledb_ctx_tpp(ctxpp);
       ctxp = null;
       ctxpp = null;
     }

--- a/src/main/java/io/tiledb/java/api/DeltaFilter.java
+++ b/src/main/java/io/tiledb/java/api/DeltaFilter.java
@@ -11,32 +11,32 @@ public class DeltaFilter extends CompressionFilter {
   public DeltaFilter(Context ctx, int level, tiledb_datatype_t type) throws TileDBError {
     super(ctx, tiledb_filter_type_t.TILEDB_FILTER_DELTA, level);
 
-    try (NativeArray reint = new NativeArray(ctx, new int[] {type.swigValue()}, Integer.class); ) {
+    NativeArray reint = new NativeArray(ctx, new int[] {type.swigValue()}, Integer.class);
 
-      ctx.handleError(
-          tiledb.tiledb_filter_set_option(
-              ctx.getCtxp(),
-              getFilterp(),
-              tiledb_filter_option_t.TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
-              reint.toVoidPointer()));
+    ctx.handleError(
+        tiledb.tiledb_filter_set_option(
+            ctx.getCtxp(),
+            getFilterp(),
+            tiledb_filter_option_t.TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
+            reint.toVoidPointer()));
 
-    } catch (TileDBError e) {
-      throw e;
-    }
+    reint.close();
   }
 
   public tiledb_datatype_t getCompressionReinterpretDatatype() throws TileDBError {
     Context ctx = getCtx();
     int datatype;
-    try (NativeArray datatypetArray = new NativeArray(ctx, 1, Integer.class)) {
-      ctx.handleError(
-          tiledb.tiledb_filter_get_option(
-              ctx.getCtxp(),
-              getFilterp(),
-              tiledb_filter_option_t.TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
-              datatypetArray.toVoidPointer()));
-      datatype = (int) datatypetArray.getItem(0);
-    }
+    NativeArray datatypetArray = new NativeArray(ctx, 1, Integer.class);
+    ctx.handleError(
+        tiledb.tiledb_filter_get_option(
+            ctx.getCtxp(),
+            getFilterp(),
+            tiledb_filter_option_t.TILEDB_COMPRESSION_REINTERPRET_DATATYPE,
+            datatypetArray.toVoidPointer()));
+    datatype = (int) datatypetArray.getItem(0);
+
+    datatypetArray.close();
+
     return tiledb_datatype_t.swigToEnum(datatype);
   }
 

--- a/src/main/java/io/tiledb/java/api/Dimension.java
+++ b/src/main/java/io/tiledb/java/api/Dimension.java
@@ -139,18 +139,15 @@ public class Dimension<T> implements AutoCloseable {
    * @throws TileDBError A TileDB exception
    */
   public String getName() throws TileDBError {
-    if (name == null) {
-      SWIGTYPE_p_p_char namepp = tiledb.new_charpp();
-      try {
-        ctx.handleError(tiledb.tiledb_dimension_get_name(ctx.getCtxp(), dimensionp, namepp));
-      } catch (TileDBError err) {
-        tiledb.delete_charpp(namepp);
-        throw err;
-      }
+    if (name != null) return name;
+    SWIGTYPE_p_p_char namepp = tiledb.new_charpp();
+    try {
+      ctx.handleError(tiledb.tiledb_dimension_get_name(ctx.getCtxp(), dimensionp, namepp));
       name = tiledb.charpp_value(namepp);
+      return name;
+    } finally {
       tiledb.delete_charpp(namepp);
     }
-    return name;
   }
 
   /**
@@ -158,18 +155,15 @@ public class Dimension<T> implements AutoCloseable {
    * @throws TileDBError A TileDB exception
    */
   public Datatype getType() throws TileDBError {
-    if (type == null) {
-      SWIGTYPE_p_tiledb_datatype_t typep = tiledb.new_tiledb_datatype_tp();
-      try {
-        ctx.handleError(tiledb.tiledb_dimension_get_type(ctx.getCtxp(), dimensionp, typep));
-      } catch (TileDBError err) {
-        tiledb.delete_tiledb_datatype_tp(typep);
-        throw err;
-      }
+    if (type != null) return type;
+    SWIGTYPE_p_tiledb_datatype_t typep = tiledb.new_tiledb_datatype_tp();
+    try {
+      ctx.handleError(tiledb.tiledb_dimension_get_type(ctx.getCtxp(), dimensionp, typep));
       type = Datatype.fromSwigEnum(tiledb.tiledb_datatype_tp_value(typep));
+      return type;
+    } finally {
       tiledb.delete_tiledb_datatype_tp(typep);
     }
-    return type;
   }
 
   /**
@@ -263,12 +257,8 @@ public class Dimension<T> implements AutoCloseable {
    * @throws TileDBError TileDBError A TileDB error
    */
   public void setCellValNum(long cellValNum) throws TileDBError {
-    try {
-      ctx.handleError(
-          tiledb.tiledb_dimension_set_cell_val_num(ctx.getCtxp(), dimensionp, cellValNum));
-    } catch (TileDBError error) {
-      throw error;
-    }
+    ctx.handleError(
+        tiledb.tiledb_dimension_set_cell_val_num(ctx.getCtxp(), dimensionp, cellValNum));
   }
 
   /**
@@ -281,10 +271,9 @@ public class Dimension<T> implements AutoCloseable {
     SWIGTYPE_p_unsigned_int uint = tiledb.new_uintp();
     try {
       ctx.handleError(tiledb.tiledb_dimension_get_cell_val_num(ctx.getCtxp(), dimensionp, uint));
-
       return tiledb.uintp_value(uint);
-    } catch (TileDBError error) {
-      throw error;
+    } finally {
+      tiledb.delete_uintp(uint);
     }
   }
 
@@ -310,6 +299,7 @@ public class Dimension<T> implements AutoCloseable {
   public void close() {
     if (dimensionp != null) {
       tiledb.tiledb_dimension_free(dimensionpp);
+      tiledb.delete_tiledb_dimension_tpp(dimensionpp);
       dimensionp = null;
       dimensionpp = null;
     }

--- a/src/main/java/io/tiledb/java/api/DimensionLabel.java
+++ b/src/main/java/io/tiledb/java/api/DimensionLabel.java
@@ -12,7 +12,7 @@ import io.tiledb.libtiledb.tiledb_datatype_t;
 import jdk.jfr.Experimental;
 
 @Experimental
-public class DimensionLabel {
+public class DimensionLabel implements AutoCloseable {
   private Context ctx;
   private SWIGTYPE_p_tiledb_dimension_label_handle_t dimlabelp;
   private SWIGTYPE_p_p_tiledb_dimension_label_handle_t dimlabelpp;
@@ -166,13 +166,11 @@ public class DimensionLabel {
     try {
       ctx.handleError(
           tiledb.tiledb_dimension_label_get_label_order(ctx.getCtxp(), this.dimlabelp, orderp));
-    } catch (TileDBError err) {
+      tiledb_data_order_t type = tiledb.tiledb_data_order_tp_value(orderp);
+      return type;
+    } finally {
       tiledb.delete_tiledb_data_order_tp(orderp);
-      throw err;
     }
-    tiledb_data_order_t type = tiledb.tiledb_data_order_tp_value(orderp);
-    tiledb.delete_tiledb_data_order_tp(orderp);
-    return type;
   }
 
   /**
@@ -187,13 +185,11 @@ public class DimensionLabel {
     try {
       ctx.handleError(
           tiledb.tiledb_dimension_label_get_label_type(ctx.getCtxp(), this.dimlabelp, typep));
-    } catch (TileDBError err) {
+      tiledb_datatype_t type = tiledb.tiledb_datatype_tp_value(typep);
+      return Datatype.fromSwigEnum(type);
+    } finally {
       tiledb.delete_tiledb_datatype_tp(typep);
-      throw err;
     }
-    tiledb_datatype_t type = tiledb.tiledb_datatype_tp_value(typep);
-    tiledb.delete_tiledb_datatype_tp(typep);
-    return Datatype.fromSwigEnum(type);
   }
 
   public void close() {

--- a/src/main/java/io/tiledb/java/api/FileStore.java
+++ b/src/main/java/io/tiledb/java/api/FileStore.java
@@ -61,13 +61,9 @@ public class FileStore {
    */
   public static void uriImport(
       Context ctx, String filestoreArrayURI, String fileURI, MimeType mimeType) throws TileDBError {
-    try {
-      ctx.handleError(
-          tiledb.tiledb_filestore_uri_import(
-              ctx.getCtxp(), filestoreArrayURI, fileURI, mimeType.toSwigEnum()));
-    } catch (TileDBError error) {
-      throw error;
-    }
+    ctx.handleError(
+        tiledb.tiledb_filestore_uri_import(
+            ctx.getCtxp(), filestoreArrayURI, fileURI, mimeType.toSwigEnum()));
   }
 
   /**
@@ -80,12 +76,7 @@ public class FileStore {
    */
   public static void uriExport(Context ctx, String filestoreArrayURI, String fileURI)
       throws TileDBError {
-    try {
-      ctx.handleError(
-          tiledb.tiledb_filestore_uri_export(ctx.getCtxp(), fileURI, filestoreArrayURI));
-    } catch (TileDBError error) {
-      throw error;
-    }
+    ctx.handleError(tiledb.tiledb_filestore_uri_export(ctx.getCtxp(), fileURI, filestoreArrayURI));
   }
 
   /**
@@ -101,13 +92,9 @@ public class FileStore {
   public static void bufferImport(
       Context ctx, String arrayUri, NativeArray buffer, long bufferSize, MimeType mimeType)
       throws TileDBError {
-    try {
-      ctx.handleError(
-          tiledb.tiledb_filestore_buffer_import(
-              ctx.getCtxp(), arrayUri, buffer.toVoidPointer(), bufferSize, mimeType.toSwigEnum()));
-    } catch (TileDBError error) {
-      throw error;
-    }
+    ctx.handleError(
+        tiledb.tiledb_filestore_buffer_import(
+            ctx.getCtxp(), arrayUri, buffer.toVoidPointer(), bufferSize, mimeType.toSwigEnum()));
   }
 
   /**
@@ -127,10 +114,10 @@ public class FileStore {
       ctx.handleError(
           tiledb.tiledb_filestore_buffer_export(
               ctx.getCtxp(), filestoreArrayURI, offset, buffer.toVoidPointer(), bufferLength));
-    } catch (TileDBError err) {
-      throw err;
+      return buffer.toJavaArray();
+    } finally {
+      buffer.close();
     }
-    return buffer.toJavaArray();
   }
 
   /**
@@ -146,12 +133,9 @@ public class FileStore {
 
     try {
       ctx.handleError(tiledb.tiledb_filestore_size(ctx.getCtxp(), filestoreURI, sizep));
-    } catch (TileDBError err) {
+      return tiledb.ulp_value(sizep);
+    } finally {
       tiledb.delete_ulp(sizep);
-      throw err;
     }
-    long result = tiledb.ulp_value(sizep);
-    tiledb.delete_ulp(sizep);
-    return result;
   }
 }

--- a/src/main/java/io/tiledb/java/api/Filter.java
+++ b/src/main/java/io/tiledb/java/api/Filter.java
@@ -38,6 +38,7 @@ public class Filter implements AutoCloseable {
   public void close() {
     if (filterp != null && filterpp != null) {
       tiledb.tiledb_filter_free(filterpp);
+      tiledb.delete_tiledb_filter_tpp(filterpp);
       filterpp = null;
       filterp = null;
     }

--- a/src/main/java/io/tiledb/java/api/FilterList.java
+++ b/src/main/java/io/tiledb/java/api/FilterList.java
@@ -143,6 +143,7 @@ public class FilterList implements AutoCloseable {
   public void close() {
     if (filter_listp != null && filter_listpp != null) {
       tiledb.tiledb_filter_list_free(filter_listpp);
+      tiledb.delete_tiledb_filter_list_tpp(filter_listpp);
       filter_listp = null;
       filter_listpp = null;
     }

--- a/src/main/java/io/tiledb/java/api/QueryCondition.java
+++ b/src/main/java/io/tiledb/java/api/QueryCondition.java
@@ -79,6 +79,8 @@ public class QueryCondition implements AutoCloseable {
                 BigInteger.valueOf(array.getSize()),
                 OP));
       }
+
+      array.close();
     } catch (TileDBError err) {
       tiledb.delete_tiledb_query_condition_tpp(conditionpp);
       throw err;
@@ -185,6 +187,8 @@ public class QueryCondition implements AutoCloseable {
               BigInteger.valueOf(array.getSize()),
               OP));
 
+      array.close();
+
     } catch (TileDBError err) {
       tiledb.delete_tiledb_query_condition_tpp(conditionpp);
       throw err;
@@ -206,6 +210,7 @@ public class QueryCondition implements AutoCloseable {
   public void close() {
     if (conditionp != null && conditionpp != null) {
       tiledb.tiledb_query_condition_free(conditionpp);
+      tiledb.delete_tiledb_query_condition_tpp(conditionpp);
       conditionpp = null;
       conditionp = null;
     }
@@ -221,9 +226,10 @@ public class QueryCondition implements AutoCloseable {
    */
   public QueryCondition combine(QueryCondition rhs, tiledb_query_condition_combination_op_t OP)
       throws TileDBError {
-    SWIGTYPE_p_p_tiledb_query_condition_t combinedCondition;
+    SWIGTYPE_p_p_tiledb_query_condition_t combinedCondition =
+        tiledb.new_tiledb_query_condition_tpp();
+
     try {
-      combinedCondition = tiledb.new_tiledb_query_condition_tpp();
       ctx.handleError(tiledb.tiledb_query_condition_alloc(ctx.getCtxp(), conditionpp));
       ctx.handleError(
           tiledb.tiledb_query_condition_combine(
@@ -244,9 +250,9 @@ public class QueryCondition implements AutoCloseable {
    * @throws TileDBError
    */
   public QueryCondition negate() throws TileDBError {
-    SWIGTYPE_p_p_tiledb_query_condition_t negatedCondition;
+    SWIGTYPE_p_p_tiledb_query_condition_t negatedCondition =
+        tiledb.new_tiledb_query_condition_tpp();
     try {
-      negatedCondition = tiledb.new_tiledb_query_condition_tpp();
       ctx.handleError(tiledb.tiledb_query_condition_alloc(ctx.getCtxp(), conditionpp));
       ctx.handleError(
           tiledb.tiledb_query_condition_negate(ctx.getCtxp(), conditionp, negatedCondition));

--- a/src/main/java/io/tiledb/java/api/TileDBString.java
+++ b/src/main/java/io/tiledb/java/api/TileDBString.java
@@ -50,6 +50,7 @@ public class TileDBString {
   public void close() {
     if (stringp != null && stringpp != null) {
       tiledb.tiledb_string_free(stringpp);
+      tiledb.delete_tiledb_string_handle_tpp(stringpp);
       stringpp = null;
       stringp = null;
     }

--- a/src/main/java/io/tiledb/java/api/Util.java
+++ b/src/main/java/io/tiledb/java/api/Util.java
@@ -66,7 +66,9 @@ public class Util {
     try (ArraySchema schema = array.getSchema()) {
       try (Domain domain = schema.getDomain()) {
         if (domain.hasDimension(fieldName)) {
-          dt = domain.getDimension(fieldName).getType();
+          Dimension dim = domain.getDimension(fieldName);
+          dt = dim.getType();
+          dim.close();
         } else {
           try (Attribute attribute = schema.getAttribute(fieldName)) {
             dt = attribute.getType();

--- a/src/main/java/io/tiledb/java/api/VFS.java
+++ b/src/main/java/io/tiledb/java/api/VFS.java
@@ -586,6 +586,7 @@ public class VFS implements AutoCloseable {
   public void close() {
     if (vfsp != null) {
       tiledb.tiledb_vfs_free(vfspp);
+      tiledb.delete_tiledb_vfs_tpp(vfspp);
       vfsp = null;
       vfspp = null;
     }

--- a/src/main/java/io/tiledb/java/api/Version.java
+++ b/src/main/java/io/tiledb/java/api/Version.java
@@ -40,12 +40,16 @@ public class Version {
     SWIGTYPE_p_int minorp = tiledb.new_intp();
     SWIGTYPE_p_int revp = tiledb.new_intp();
     tiledb.tiledb_version(majorp, minorp, revp);
-    this.major = tiledb.intp_value(majorp);
-    this.minor = tiledb.intp_value(minorp);
-    this.rev = tiledb.intp_value(revp);
-    tiledb.delete_intp(majorp);
-    tiledb.delete_intp(minorp);
-    tiledb.delete_intp(revp);
+
+    try {
+      this.major = tiledb.intp_value(majorp);
+      this.minor = tiledb.intp_value(minorp);
+      this.rev = tiledb.intp_value(revp);
+    } finally {
+      tiledb.delete_intp(majorp);
+      tiledb.delete_intp(minorp);
+      tiledb.delete_intp(revp);
+    }
   }
 
   /** @return The major number. */


### PR DESCRIPTION
# Memory leaks

The resource management in the Java API is inconsistent and in some cases non-existent. I have used the Instruments application from Xcode to detect memory leaks. These memory leaks occurred in various ways which I explain with examples below.

## Leak kind 1 - Example 1 (Incomplete close())
In the Domain constructor we use ```ctx.handleError(tiledb.tiledb_domain_alloc(ctx.getCtxp(), _domainpp));```
This ```_domainpp``` has been created like this:
```SWIGTYPE_p_p_tiledb_domain_t _domainpp = tiledb.new_tiledb_domain_tpp();```

The problem is that even though the Domain object is ```AutoClosable``` and the ```close()``` method is being called correctly, we were missing this delete call:
```tiledb.delete_tiledb_domain_tpp(_domainpp);```

We were only calling ```tiledb.tiledb_domain_free(domainpp);```   which in my mind should delete the pointer but it did not. This practice is used throughout the Java API and was present long before me so I can not be sure why it was implemented this way.

## Leak kind 2 - Example 2 (Leaking pointer)

Previous implementation:
```java
  public int getAllowDups() throws TileDBError {
    SWIGTYPE_p_int allowsDupsPtr = tiledb.new_intp();
    try {
      ctx.handleError(
          tiledb.tiledb_array_schema_get_allows_dups(ctx.getCtxp(), getSchemap(), allowsDupsPtr));

      return tiledb.intp_value(allowsDupsPtr);
    } catch (TileDBError err) {
      tiledb.delete_intp(allowsDupsPtr);
      throw err;
    }
  }

```

The ```SWIGTYPE_p_int allowsDupsPtr``` above is leaking. Methods of this type have been changed to:

```java
  public int getAllowDups() throws TileDBError {
    SWIGTYPE_p_int allowsDupsPtr = tiledb.new_intp();
    try {
      ctx.handleError(
          tiledb.tiledb_array_schema_get_allows_dups(ctx.getCtxp(), getSchemap(), allowsDupsPtr));

      return tiledb.intp_value(allowsDupsPtr);
    } finally {
      tiledb.delete_intp(allowsDupsPtr);
    }
  }
  ```
  
  The ```finally``` keyword is ideal for resource management. It runs regardless of the execution success. 


## Leak kind 3 - Example 3 (Internal use of TileDB objects)

This leak refers to cases where the API was using its own objects but was not releasing its resources after use.

```java
  public synchronized SubArray addRangeByName(String name, Object start, Object end, Object stride)
      throws TileDBError {
    Datatype dimType;
    try (ArraySchema schema = array.getSchema();
        Domain domain = schema.getDomain()) {
      dimType = domain.getDimension(name).getType();
    }
```

In the example above, ```getDimension()``` returns a ```new Dimension()``` object which is never ```closed()```. These kind of methods have been changed to:

```java
  public synchronized SubArray addRangeByName(String name, Object start, Object end, Object stride)
      throws TileDBError {
    Datatype dimType;
    try (ArraySchema schema = array.getSchema();
        Domain domain = schema.getDomain();
        Dimension dim = domain.getDimension(name)) {
      dimType = dim.getType();
    }
```

## Leak kind 4
Some Classes were not implementing the ```AutoClosable``` interface. (```FragmentInfo```, ```DimensionLabel```)

# Extra
Finally I have removed all ```try{}catch(){}``` blocks from the setters across the API as they were useless. ```ctx.handleError()``` throws errors with their messages. This is not relevant to the leaks but adds consistency in the code. Example:

before:
```java
  public void setFillValue(NativeArray value, BigInteger size) throws TileDBError {
    Util.checkBigIntegerRange(size);
    try {
      ctx.handleError(
          tiledb.tiledb_attribute_set_fill_value(
              ctx.getCtxp(), attributep, value.toVoidPointer(), size));
    } catch (TileDBError err) {
      throw err;
    }
  }
```

after:
```java 
  public void setFillValue(NativeArray value, BigInteger size) throws TileDBError {
    Util.checkBigIntegerRange(size);
    ctx.handleError(
        tiledb.tiledb_attribute_set_fill_value(
            ctx.getCtxp(), attributep, value.toVoidPointer(), size));
  }
```