### PR TITLE
fix maven empty upload

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -229,10 +229,10 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
-  Setup-Release:
+  Mock-Release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [Create_Artifacts_Ubuntu_MacOS, Create_Artifacts_Windows]
-    name: Setup-Release
+    name: Mock-Release
     runs-on: ubuntu-latest
     steps:
 
@@ -248,48 +248,10 @@ jobs:
 
       - uses: actions/download-artifact@v2
 
-      - name: Create-Jars
+      - name: assemble
         run: |
-          set +e
-
-          mv Upload-*/* .
-
-          mkdir -p ./build/install/lib
-          mkdir -p ./build/install/arm/lib
-          mkdir ./build/install/lib64
-          mkdir ./build/tiledb_jni/
-          mkdir ./build/tiledb_jni/arm
-          mkdir ./build/tiledb_jni/Release
-          mkdir ./build/install/bin
-
-
-          for arch in $(ls | grep .gz.tar)
-          do
-          tar -xvf $arch
-          done
-
-          mv binaries_*/* .
-
-          # OSX
-          mv libtiledb.dylib ./build/install/lib
-          mv libtiledbjni.dylib ./build/tiledb_jni
-          mv arm/libtiledb.dylib ./build/install/arm/lib
-          mv arm/libtiledbjni.dylib ./build/tiledb_jni/arm
-          
-          # Linux
-          cp libtiledb.so ./build/install/lib
-          mv libtiledb.so ./build/install/lib64
-          mv libtiledbjni.so ./build/tiledb_jni
-
-          # Windows
-          mv tbb.dll ./build/install/bin
-          mv tiledb.dll ./build/install/bin
-          mv tiledbjni.dll ./build/tiledb_jni/Release
-
-          ./gradlew assemble
-
-          mkdir jars
-          cp ./build/libs/*.jar jars
+          chmod +x ./ci/assemble_full_jar.sh
+          ./ci/assemble_full_jar.sh
 
       - uses: actions/upload-artifact@v3
         with:
@@ -301,10 +263,10 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
 
-  Test-Release:
+  Test-Mock-Release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [ Setup-Release ]
-    name: Test-Release
+    needs: [ Mock-Release ]
+    name: Test-Mock-Release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -353,10 +315,9 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
-  Release:
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [ Test-Release ]
-    name: Release
+  Actual-Release:
+    needs: [ Test-Mock-Release ]
+    name: Actual-Release
     runs-on: ubuntu-latest
     steps:
 
@@ -364,13 +325,11 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v2
-        with:
-          name: jars
 
-      - name: Package jars
+      - name: assemble
         run: |
-          mkdir jars;
-          mv *.jar ./jars;
+          chmod +x ./ci/assemble_full_jar.sh;
+          ./ci/assemble_full_jar.sh;
 
       - name: Create Release
         id: create_release

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.0-SNAPSHOT'
+version '0.19.1-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/ci/assemble_full_jar.sh
+++ b/ci/assemble_full_jar.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set +e
+
+mv Upload-*/* .
+
+mkdir -p ./build/install/lib
+mkdir -p ./build/install/arm/lib
+mkdir ./build/install/lib64
+mkdir ./build/tiledb_jni/
+mkdir ./build/tiledb_jni/arm
+mkdir ./build/tiledb_jni/Release
+mkdir ./build/install/bin
+
+
+for arch in $(ls | grep .gz.tar)
+do
+tar -xvf $arch
+done
+
+mv binaries_*/* .
+
+# OSX
+mv libtiledb.dylib ./build/install/lib
+mv libtiledbjni.dylib ./build/tiledb_jni
+mv arm/libtiledb.dylib ./build/install/arm/lib
+mv arm/libtiledbjni.dylib ./build/tiledb_jni/arm
+
+# Linux
+cp libtiledb.so ./build/install/lib
+mv libtiledb.so ./build/install/lib64
+mv libtiledbjni.so ./build/tiledb_jni
+
+# Windows
+mv tbb.dll ./build/install/bin
+mv tiledb.dll ./build/install/bin
+mv tiledbjni.dll ./build/tiledb_jni/Release
+
+./gradlew assemble
+
+mkdir jars
+cp ./build/libs/*.jar jars


### PR DESCRIPTION
Small fix because our latest maven upload did not contain the native libs. That was caused by #310 
The issue is only present in the maven release. Not in the release jar in github.