### PR TITLE
Always link to tiledb dynamically.

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -106,7 +106,6 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: OFF
 
   Create_Artifacts_Windows:
-    if: startsWith(github.ref, 'refs/tags/') || contains(github.ref, 'test')
     needs: [Test_Windows, Examples]
     name: Create_Artifacts_Windows
     runs-on: windows-2019
@@ -153,7 +152,6 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
   Create_Artifacts_Ubuntu_MacOS:
-    if: startsWith(github.ref, 'refs/tags/') || contains(github.ref, 'test')
     needs: [Test_Ubuntu_macOS, Examples]
     name: Create_Artifacts_Ubuntu_MacOS
     runs-on: ${{ matrix.os }}
@@ -230,7 +228,6 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
   Mock-Release:
-    if: startsWith(github.ref, 'refs/tags/')
     needs: [Create_Artifacts_Ubuntu_MacOS, Create_Artifacts_Windows]
     name: Mock-Release
     runs-on: ubuntu-latest
@@ -264,7 +261,6 @@ jobs:
 
 
   Test-Mock-Release:
-    if: startsWith(github.ref, 'refs/tags/')
     needs: [ Mock-Release ]
     name: Test-Mock-Release
     runs-on: ${{ matrix.os }}
@@ -341,20 +337,20 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           name: ${{ github.event.release.tag_name }}
           body: ${{steps.github_release.outputs.changelog}}
-          draft: false
+          draft: true
           prerelease: false
 
-      - name: Upload to maven
-        run: |
-          chmod +x ./ci/upload_to_maven.sh
-          ./ci/upload_to_maven.sh
-        shell: bash
-        env:
-          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          GPG_SECRET_KEYS_ENC: ${{ secrets.GPG_SECRET_KEYS_ENC }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+#      - name: Upload to maven
+#        run: |
+#          chmod +x ./ci/upload_to_maven.sh
+#          ./ci/upload_to_maven.sh
+#        shell: bash
+#        env:
+#          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+#          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+#          GPG_SECRET_KEYS_ENC: ${{ secrets.GPG_SECRET_KEYS_ENC }}
+#          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+#          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     env:
       ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
       ORG_GRADLE_PROJECT_TILEDB_S3: ON

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -106,6 +106,7 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: OFF
 
   Create_Artifacts_Windows:
+    if: startsWith(github.ref, 'refs/tags/') || contains(github.ref, 'test')
     needs: [Test_Windows, Examples]
     name: Create_Artifacts_Windows
     runs-on: windows-2019
@@ -152,6 +153,7 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
   Create_Artifacts_Ubuntu_MacOS:
+    if: startsWith(github.ref, 'refs/tags/') || contains(github.ref, 'test')
     needs: [Test_Ubuntu_macOS, Examples]
     name: Create_Artifacts_Ubuntu_MacOS
     runs-on: ${{ matrix.os }}
@@ -228,6 +230,7 @@ jobs:
       ORG_GRADLE_PROJECT_TILEDB_S3: ON
 
   Mock-Release:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [Create_Artifacts_Ubuntu_MacOS, Create_Artifacts_Windows]
     name: Mock-Release
     runs-on: ubuntu-latest
@@ -261,6 +264,7 @@ jobs:
 
 
   Test-Mock-Release:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [ Mock-Release ]
     name: Test-Mock-Release
     runs-on: ${{ matrix.os }}
@@ -337,20 +341,20 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           name: ${{ github.event.release.tag_name }}
           body: ${{steps.github_release.outputs.changelog}}
-          draft: true
+          draft: false
           prerelease: false
 
-#      - name: Upload to maven
-#        run: |
-#          chmod +x ./ci/upload_to_maven.sh
-#          ./ci/upload_to_maven.sh
-#        shell: bash
-#        env:
-#          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-#          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-#          GPG_SECRET_KEYS_ENC: ${{ secrets.GPG_SECRET_KEYS_ENC }}
-#          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-#          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      - name: Upload to maven
+        run: |
+          chmod +x ./ci/upload_to_maven.sh
+          ./ci/upload_to_maven.sh
+        shell: bash
+        env:
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_SECRET_KEYS_ENC: ${{ secrets.GPG_SECRET_KEYS_ENC }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     env:
       ORG_GRADLE_PROJECT_TILEDB_SERIALIZATION: ON
       ORG_GRADLE_PROJECT_TILEDB_S3: ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,36 +116,10 @@ target_link_libraries(tiledbjni
     ${JAVA_JVM_LIBRARY}
 )
 
-if (WIN32)
-  get_target_property(LIBMAGIC_LIB libmagic IMPORTED_LOCATION)
-  get_filename_component(LIBMAGIC_LIB_PATH ${LIBMAGIC_LIB} DIRECTORY)
-  find_library(PCRE2_POSIX pcre2-posix REQUIRED PATHS ${LIBMAGIC_LIB_PATH})
-  find_library(PCRE2_8 pcre2-8 REQUIRED PATHS ${LIBMAGIC_LIB_PATH})
-  target_link_libraries(tiledbjni
-    PRIVATE
-      ${PCRE2_POSIX}
-      ${PCRE2_8}
-      WebServices
-      Winhttp
-      Wininet
-      Userenv
-      Version
-      Secur32
-      Ncrypt
-  )
-endif()
-
-if (TARGET TileDB::tiledb_static)
-  target_link_libraries(tiledbjni
-    PRIVATE
-      TileDB::tiledb_static
-  )
-else()
-  target_link_libraries(tiledbjni
-    PRIVATE
-      TileDB::tiledb_shared
-  )
-endif()
+target_link_libraries(tiledbjni
+  PRIVATE
+    TileDB::tiledb_shared
+)
 
 # Set rpath to be relative to the .so.
 if (APPLE)


### PR DESCRIPTION
[SC-34269](https://app.shortcut.com/tiledb-inc/story/34269/reconsider-having-tiledbjni-statically-link-to-tiledb-on-windows)

Since the macOS and Linux release artifacts already contain only dynamic libraries, this should have effect only on Windows (where we bundle `tiledb.dll` in the maven package either way).

Let's see what CI thinks.