### PR TITLE
remove domain caching in Array class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.3-SNAPSHOT'
+version '0.19.4-SNAPSHOT'
 
 repositories {
     jcenter()


### PR DESCRIPTION
This was causing issues in Spark as it throws :

https://github.com/TileDB-Inc/TileDB-Spark/actions/runs/6666383298/job/18117809533

It has to do with the resource managment. In a previous PR I added domain caching in the array class. Removing it solves the issue (tested locally). It was a minor optimization anyways with questionable performance implications. 