### PR TITLE
fixing ```close()``` in the Context and Domain classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.3-SNAPSHOT'
+version '0.19.4-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/src/main/java/io/tiledb/java/api/Context.java
+++ b/src/main/java/io/tiledb/java/api/Context.java
@@ -59,6 +59,7 @@ public class Context implements AutoCloseable {
   private SWIGTYPE_p_p_tiledb_ctx_t ctxpp;
   private SWIGTYPE_p_tiledb_ctx_t ctxp;
   private ContextCallback errorHandler;
+  private Config config;
 
   /**
    * Constructor. Creates a TileDB Context with default configuration.
@@ -181,6 +182,7 @@ public class Context implements AutoCloseable {
       tiledb.delete_tiledb_ctx_tpp(_ctxpp);
       throw new TileDBError("[TileDB::JavaAPI] Error: Failed to create context");
     }
+    this.config = config;
     this.ctxpp = _ctxpp;
     this.ctxp = tiledb.tiledb_ctx_tpp_value(_ctxpp);
     this.errorHandler = new ContextCallback();
@@ -258,8 +260,8 @@ public class Context implements AutoCloseable {
   /**
    * Close the context and delete all native objects. Should be called always to cleanup the context
    */
-  public void close() throws TileDBError {
-    this.getConfig().close();
+  public void close() {
+    config.close();
     if (ctxp != null) {
       tiledb.tiledb_ctx_free(ctxpp);
       tiledb.delete_tiledb_ctx_tpp(ctxpp);

--- a/src/main/java/io/tiledb/java/api/Domain.java
+++ b/src/main/java/io/tiledb/java/api/Domain.java
@@ -297,6 +297,8 @@ public class Domain implements AutoCloseable {
     if (domainp != null) {
       tiledb.tiledb_domain_free(domainpp);
       tiledb.delete_tiledb_domain_tpp(domainpp);
+      domainpp = null;
+      domainp = null;
     }
   }
 }


### PR DESCRIPTION
This PR fixes some bugs in the resource management of the Domain and Context classes. 

- In the domain class we were not assigning the ```domainp``` and ```domainpp``` with null in the ```close()``` method which was causing issues in Spark were the ```close()``` method is called multiple times. 


- In the context class we were using the internal ```Config``` object wrongly. 