### PR TITLE
remove arm release testing because github runner is not arm

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -265,7 +265,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-11, ubuntu-latest, macos-13-xlarge, windows-2019 ]
+        os: [ macos-11, ubuntu-latest, windows-2019 ]
     steps:
 
       - name: Checkout

--- a/ci/assemble_full_jar.sh
+++ b/ci/assemble_full_jar.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set +e
-
 mv Upload-*/* .
 
 mkdir -p ./build/install/lib


### PR DESCRIPTION
Proof: draft PR for testing is here: https://github.com/TileDB-Inc/TileDB-Java/pull/322

Runner output: https://github.com/TileDB-Inc/TileDB-Java/actions/runs/6959595802/job/18937321229#step:5:49

It seems that the runner ```aarch``` is not longer ```aarch64``` so our ```NativeLibLoader.class``` does not find the arm native lib. Even after I change the ```NativeLibLoader``` to force it to find the arm lib ```System.loadLibrary()``` throws a linker error. 

I have removed the step that fails because it's job was to only test if the final jar was good on all platforms. I have personally tested the jar in an M1 mac and it works fine.  Everything else remains untouched.