### PR TITLE
move away from deprecated methods step1

### DIFF
--- a/src/main/java/io/tiledb/java/api/Array.java
+++ b/src/main/java/io/tiledb/java/api/Array.java
@@ -774,6 +774,7 @@ public class Array implements AutoCloseable {
    *     timestamp.
    * @throws TileDBError
    */
+  @Deprecated
   public void deleteFragments(BigInteger timestampStart, BigInteger timestampEnd)
       throws TileDBError {
     Util.checkBigIntegerRange(timestampStart);
@@ -781,6 +782,25 @@ public class Array implements AutoCloseable {
     ctx.handleError(
         tiledb.tiledb_array_delete_fragments(
             ctx.getCtxp(), getArrayp(), uri, timestampStart, timestampEnd));
+  }
+
+  /**
+   * Deletes array fragments written between the input timestamps.
+   *
+   * @param ctx The Context
+   * @param uri The array URI
+   * @param timestampStart The epoch timestamp in milliseconds.
+   * @param timestampEnd The epoch timestamp in milliseconds. Use UINT64_MAX for the current
+   *     timestamp.
+   * @throws TileDBError
+   */
+  public static void deleteFragments(
+      Context ctx, String uri, BigInteger timestampStart, BigInteger timestampEnd)
+      throws TileDBError {
+    Util.checkBigIntegerRange(timestampStart);
+    Util.checkBigIntegerRange(timestampEnd);
+    ctx.handleError(
+        tiledb.tiledb_array_delete_fragments_v2(ctx.getCtxp(), uri, timestampStart, timestampEnd));
   }
 
   /**

--- a/src/main/java/io/tiledb/java/api/FragmentInfo.java
+++ b/src/main/java/io/tiledb/java/api/FragmentInfo.java
@@ -778,17 +778,18 @@ public class FragmentInfo implements AutoCloseable {
    * @deprecated use getFragmentNameV2(long fragmentID) instead
    * @throws TileDBError
    */
-  @Deprecated
   public String getFragmentName(long fragmentID) throws TileDBError {
-    SWIGTYPE_p_p_char name = tiledb.new_charpp();
+    SWIGTYPE_p_p_tiledb_string_handle_t name = tiledb.new_tiledb_string_handle_tpp();
+    TileDBString ts = null;
 
     try {
       ctx.handleError(
-          tiledb.tiledb_fragment_info_get_fragment_name(
+          tiledb.tiledb_fragment_info_get_fragment_name_v2(
               ctx.getCtxp(), fragmentInfop, fragmentID, name));
-      return tiledb.charpp_value(name);
+      ts = new TileDBString(ctx, name);
+      return ts.getView().getFirst();
     } finally {
-      tiledb.delete_charpp(name);
+      if (ts != null) ts.close();
     }
   }
 
@@ -799,6 +800,7 @@ public class FragmentInfo implements AutoCloseable {
    * @return The fragment name.
    * @throws TileDBError
    */
+  @Deprecated
   public TileDBString getFragmentNameV2(long fragmentID) throws TileDBError {
     SWIGTYPE_p_p_tiledb_string_handle_t name = tiledb.new_tiledb_string_handle_tpp();
     TileDBString ts = null;

--- a/src/main/java/io/tiledb/java/api/Group.java
+++ b/src/main/java/io/tiledb/java/api/Group.java
@@ -187,6 +187,7 @@ public class Group implements AutoCloseable {
     }
   }
 
+  @Deprecated
   /**
    * Get the URI of a member of a group by index and details of group
    *
@@ -195,6 +196,17 @@ public class Group implements AutoCloseable {
    * @throws TileDBError
    */
   public String getMemberByIndexV2(BigInteger index) throws TileDBError {
+    return getMemberByIndex(index);
+  }
+
+  /**
+   * Get the URI of a member of a group by index and details of group
+   *
+   * @param index the index of the member.
+   * @return the corresponding member in the group.
+   * @throws TileDBError
+   */
+  public String getMemberByIndex(BigInteger index) throws TileDBError {
     Util.checkBigIntegerRange(index);
     SWIGTYPE_p_tiledb_object_t objtypep = tiledb.new_tiledb_object_tp();
     SWIGTYPE_p_p_tiledb_string_handle_t uripp = tiledb.new_tiledb_string_handle_tpp();
@@ -212,6 +224,7 @@ public class Group implements AutoCloseable {
     }
   }
 
+  @Deprecated
   /**
    * Get the URI of a member of a group by name
    *
@@ -220,6 +233,17 @@ public class Group implements AutoCloseable {
    * @throws TileDBError
    */
   public String getMemberByNameV2(String name) throws TileDBError {
+    return getMemberByName(name);
+  }
+
+  /**
+   * Get the URI of a member of a group by name
+   *
+   * @param name the name of the member
+   * @return the URI of the member with the given name
+   * @throws TileDBError
+   */
+  public String getMemberByName(String name) throws TileDBError {
     SWIGTYPE_p_tiledb_object_t objtypep = tiledb.new_tiledb_object_tp();
     SWIGTYPE_p_p_tiledb_string_handle_t uripp = tiledb.new_tiledb_string_handle_tpp();
     TileDBString ts = null;

--- a/src/test/java/io/tiledb/java/api/FragmentsTest.java
+++ b/src/test/java/io/tiledb/java/api/FragmentsTest.java
@@ -224,9 +224,7 @@ public class FragmentsTest {
 
   @Test
   public void testDeleteFragments() throws Exception {
-    Array array = new Array(ctx, arrayURI, TILEDB_MODIFY_EXCLUSIVE);
-
-    array.deleteFragments(BigInteger.valueOf(10L), BigInteger.valueOf(20L));
+    Array.deleteFragments(ctx, arrayURI, BigInteger.valueOf(10L), BigInteger.valueOf(20L));
 
     File f = new File(arrayURI);
     int nFiles = 0;
@@ -239,6 +237,5 @@ public class FragmentsTest {
     }
     Assert.assertEquals(1, nFiles);
     Assert.assertTrue(frag.getName().startsWith("__30_30_"));
-    array.close();
   }
 }

--- a/src/test/java/io/tiledb/java/api/GroupTest.java
+++ b/src/test/java/io/tiledb/java/api/GroupTest.java
@@ -130,10 +130,10 @@ public class GroupTest {
     Assert.assertEquals(3, group.getMemberCount());
 
     // test getters
-    String[] uri = group.getMemberByNameV2("array3Name").split("/");
+    String[] uri = group.getMemberByName("array3Name").split("/");
     Assert.assertEquals("TileDB-Java/array3", uri[uri.length - 2] + "/" + uri[uri.length - 1]);
 
-    Assert.assertEquals("array2Name", group.getMemberByIndexV2(new BigInteger("1")));
+    Assert.assertEquals("array2Name", group.getMemberByIndex(new BigInteger("1")));
 
     // remove a member
     group.reopen(ctx, TILEDB_WRITE);


### PR DESCRIPTION
These methods have a ```v2``` equivalent in the c api. 
```java
tiledb_fragment_info_get_fragment_name()
tiledb_group_get_member_by_index()
tiledb_group_get_member_by_name()
```

When the v2 was introduced I wrapped them with the v2 in the signature. Example: ```getMemberByNameV2()```

This is a bit ugly so I am now deprecating the versions with the v2 in the signature in favor of the old signatures. The methods with the old signatures are now using the v2 c_apis


```tiledb_array_delete_fragments()``` is a different case. It is now deprecated and replaced by a static method. 



This PR removed the dependency to deprecated methods completely without introducing any breaking changes. Let me know if you want to also remove the deprecated methods completely. 

[sc-45973]