### PR TITLE
Update the build script to ensure compatibility with Gradle 9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ group 'io.tiledb'
 version '0.26.0-SNAPSHOT'
 
 repositories {
-    jcenter()
     mavenCentral()
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
@@ -24,8 +23,10 @@ nexusStaging {
     password = System.getenv('SONATYPE_PASSWORD')
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+}
 
 sourceSets {
     main {


### PR DESCRIPTION
[SC-49342](https://app.shortcut.com/tiledb-inc/story/49342/fix-usage-of-deprecated-gradle-constructs)

This PR updates the build script to stop using deprecated constructs that will be removed with Gradle 9. See the following pages for more information:

* https://docs.gradle.org/8.7/userguide/upgrading_version_6.html#jcenter_deprecation
* https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#java_convention_deprecation