### PR TITLE
Migrate CI to windows-2022

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Test_Windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || contains(github.ref, 'test')
     needs: [Test_Windows, Examples]
     name: Create_Artifacts_Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -265,7 +265,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, macos-14, windows-2019 ]
+        os: [ ubuntu-22.04, macos-13, macos-14, windows-2022 ]
     steps:
 
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
         name: Test
 
   Test_Windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The Windows Server 2019 image is deprecated in GitHub Actions ([announcement](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down)):

> This image will be fully retired by June 30, 2025.

The first brownout period is today, and thus the Windows job wouldn't even run when I did a [manual trigger on my fork](https://github.com/jdblischak/TileDB-Java/actions/runs/15421458455/job/43397374299):

![image](https://github.com/user-attachments/assets/39c0fa5e-d04a-4f7e-8dfb-e9d9914824eb)
