### PR TITLE
use newer docker for linux release artifacts

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -173,8 +173,8 @@ jobs:
           mkdir binaries_$RUNNER_OS
 
           if [[ ( "$RUNNER_OS" == "Linux" ) ]]; then
-            docker build -f ci/Dockerfile2010 . -t lib_builder_2010
-            docker run -e "CFLAGS=$CFLAGS" -e "CPPFLAGS=$CPPFLAGS" -v $(pwd):/TileDB-Java -t lib_builder_2010 /TileDB-Java/ci/build.sh
+            docker build -f ci/Dockerfile2014 . -t lib_builder_2014
+            docker run -e "CFLAGS=$CFLAGS" -e "CPPFLAGS=$CPPFLAGS" -v $(pwd):/TileDB-Java -t lib_builder_2014 /TileDB-Java/ci/build.sh
             cp ./build/tiledb_jni/*.so ./build/install/lib/*.so ./build/install/lib64/*.so binaries_$RUNNER_OS/
           fi
           

--- a/ci/Dockerfile2014
+++ b/ci/Dockerfile2014
@@ -1,0 +1,9 @@
+# Dockerfile for lowest common denominator Linux native artifact build
+# --------------------------------------------------------------------
+FROM quay.io/pypa/manylinux2014_x86_64
+
+RUN yum install -y java-1.8.0-openjdk-devel
+RUN yum remove -y cmake
+
+ENV PATH /opt/python/cp38-cp38/bin:${PATH}
+RUN pip install cmake==3.17.3


### PR DESCRIPTION
Releases still fail because of:

Linux Docker build fails to create linux artifacts resulting in empty jars and lining errors. 
This PR keeps the docker build in the CI but updates to a newer image to fix the problem and maintain as much backwards compatibility as possible. 


https://github.com/TileDB-Inc/TileDB-Java/actions/runs/20881432317/job/60267174700#step:4:505



here is a test run that confirms the fix https://github.com/TileDB-Inc/TileDB-Java/actions/runs/20970018910/job/60271073767. This test run was made by a modified branch to only test that part of the workflow