### PR TITLE
update Gradle build configuration and CI script for Sonatype publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 plugins {
-   id 'java-library'
-   id 'idea'
-   id 'maven-publish'
-   id 'signing'
-   id 'com.github.sherter.google-java-format' version '0.9'
-   id 'com.google.osdetector' version '1.6.0'
+    id 'java-library'
+    id 'idea'
+    id 'maven-publish'
+    id 'signing'
+    id 'com.github.sherter.google-java-format' version '0.9'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
+    id 'com.google.osdetector' version '1.6.0'
 }
 
 group 'io.tiledb'
@@ -12,9 +13,6 @@ version '0.31.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
-    maven {
-        url "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots"
-    }
 }
 
 java {
@@ -238,16 +236,15 @@ publishing {
             }
         }
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username System.getenv('SONATYPE_CENTRAL_USERNAME')
-                password System.getenv('SONATYPE_CENTRAL_PASSWORD')
-            }
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(System.getenv("SONATYPE_CENTRAL_USERNAME"))
+            password.set(System.getenv("SONATYPE_CENTRAL_PASSWORD"))
         }
     }
 }

--- a/ci/upload_to_maven.sh
+++ b/ci/upload_to_maven.sh
@@ -5,10 +5,11 @@ echo "Starting upload to maven"
 echo "${GPG_SECRET_KEYS_ENC}" | base64 --decode > $GPG_KEY_LOCATION
 ./gradlew properties -q | grep "version:" | awk '{print $2}'
 export PROJECT_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
-# Upload only snapshots to sonatype oss so it can make its way to maven central
-./gradlew publishMavenJavaPublicationToMavenRepository
 
-# Only non-snapshot can be pushed as maven releases
+# Publish to Sonatype (Central Portal via OSSRH Staging API).
+# IMPORTANT: close/release must run in the SAME Gradle invocation so the plugin can reuse the created staging repository id.
 if [[ ! $(echo "${PROJECT_VERSION}" | grep "SNAPSHOT") ]]; then
-  ./gradlew closeAndReleaseRepository
+  ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+else
+  ./gradlew publishToSonatype
 fi


### PR DESCRIPTION
This PR fixes maven publishing by switching to the new `io.github.gradle-nexus.publish-plugin` plugin.

The proof is this run: https://github.com/TileDB-Inc/TileDB-Java/actions/runs/21172856980 which comes from a heavily modified branch that only tested maven uploads. 

By using that branch I was able to successfully upload the latest release to maven: https://central.sonatype.com/artifact/io.tiledb/tiledb-java/0.31.0. Previously uploads to maven were broken for some time. 

This PR ports the proven fixes so that future releases work out of the box when creating new tags. 